### PR TITLE
Handled edge cases for the {{local-class}} helper

### DIFF
--- a/embroider-css-modules/package.json
+++ b/embroider-css-modules/package.json
@@ -67,6 +67,7 @@
     "@glint/template": "^v1.0.0-beta.4",
     "@tsconfig/ember": "^2.0.0",
     "@types/ember__component": "^4.0.12",
+    "@types/ember__debug": "^4.0.3",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.0",
     "concurrently": "^8.0.1",

--- a/embroider-css-modules/src/helpers/local-class.ts
+++ b/embroider-css-modules/src/helpers/local-class.ts
@@ -1,4 +1,5 @@
 import Helper from '@ember/component/helper';
+import { assert } from '@ember/debug';
 
 type IndexSignatureParameter = string | number | symbol;
 
@@ -23,6 +24,8 @@ export default class LocalClassHelper<
 > extends Helper<LocalClassHelperSignature<T>> {
   compute(positional: LocalClassHelperSignature<T>['Args']['Positional']) {
     const [styles, ...localClassNames] = positional;
+
+    assert('The styles object is undefined.', styles);
 
     const classNames = localClassNames.reduce((accumulator, localClassName) => {
       if (localClassName === undefined || localClassName === null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       '@types/ember__component':
         specifier: ^4.0.12
         version: 4.0.12(@babel/core@7.21.4)
+      '@types/ember__debug':
+        specifier: ^4.0.3
+        version: 4.0.3(@babel/core@7.21.4)
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.57.0
         version: 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@4.9.5)

--- a/test-app/tests/integration/helpers/local-class/compatibility-with-ember-test.ts
+++ b/test-app/tests/integration/helpers/local-class/compatibility-with-ember-test.ts
@@ -47,7 +47,8 @@ module('Integration | Helper | local-class', function (hooks) {
         .dom('[data-test-element]')
         .hasAttribute(
           'class',
-          'container-hashed is-wide-hashed is-inline-hashed'
+          'container-hashed is-wide-hashed is-inline-hashed',
+          'We see the correct global class names.'
         );
     });
 
@@ -64,7 +65,8 @@ module('Integration | Helper | local-class', function (hooks) {
         .dom('[data-test-element]')
         .hasAttribute(
           'class',
-          'p-4 container-hashed is-wide-hashed is-inline-hashed my-2'
+          'p-4 container-hashed is-wide-hashed is-inline-hashed my-2',
+          'We see the correct global class names.'
         );
     });
 
@@ -93,7 +95,8 @@ module('Integration | Helper | local-class', function (hooks) {
         .dom('[data-test-element]')
         .hasAttribute(
           'class',
-          'container-hashed is-inline-hashed no-feedback-hashed'
+          'container-hashed is-inline-hashed no-feedback-hashed',
+          'We see the correct global class names.'
         );
     });
 
@@ -113,7 +116,8 @@ module('Integration | Helper | local-class', function (hooks) {
         .dom('[data-test-element]')
         .hasAttribute(
           'class',
-          'container-hashed is-wide-hashed is-inline-hashed'
+          'container-hashed is-wide-hashed is-inline-hashed',
+          'We see the correct global class names.'
         );
     });
   });

--- a/test-app/tests/integration/helpers/local-class/error-handling-test.ts
+++ b/test-app/tests/integration/helpers/local-class/error-handling-test.ts
@@ -36,7 +36,13 @@ module('Integration | Helper | local-class', function (hooks) {
         </div>
       `);
 
-      assert.dom('[data-test-element]').hasAttribute('class', 'is-wide-hashed');
+      assert
+        .dom('[data-test-element]')
+        .hasAttribute(
+          'class',
+          'is-wide-hashed',
+          'We see the correct global class names.'
+        );
     });
 
     test('does not ignore duplicated local class names', async function (this: TestContext, assert) {
@@ -52,7 +58,8 @@ module('Integration | Helper | local-class', function (hooks) {
         .dom('[data-test-element]')
         .hasAttribute(
           'class',
-          'is-wide-hashed container-hashed is-wide-hashed is-inline-hashed'
+          'is-wide-hashed container-hashed is-wide-hashed is-inline-hashed',
+          'We see the correct global class names.'
         );
     });
   });

--- a/test-app/tests/integration/helpers/local-class/styles-empty-object-test.ts
+++ b/test-app/tests/integration/helpers/local-class/styles-empty-object-test.ts
@@ -1,35 +1,48 @@
+import { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 
+interface TestContext extends BaseTestContext {
+  styles: Record<string, never>;
+}
+
 module('Integration | Helper | local-class', function (hooks) {
   setupRenderingTest(hooks);
 
-  module('When styles is an empty object', function () {
-    test('returns an empty string when there are no local class names', async function (assert) {
-      await render(hbs`
-        <div
-          class={{local-class (hash)}}
-          data-test-element
-        >
-        </div>
-      `);
-
-      assert.dom('[data-test-element]').hasAttribute('class', '');
+  module('When styles is an empty object', function (nestedHooks) {
+    nestedHooks.beforeEach(function (this: TestContext) {
+      this.styles = {};
     });
 
-    test('returns an empty string when there are local class names', async function (assert) {
-      await render(hbs`
+    test('returns an empty string when there are no local class names', async function (this: TestContext, assert) {
+      await render<TestContext>(hbs`
         <div
-          {{! @glint-expect-error: We are testing a special case (styles is an empty object) }}
-          class={{local-class (hash) "container" "is-wide" "is-inline"}}
+          class={{local-class this.styles}}
           data-test-element
         >
         </div>
       `);
 
-      assert.dom('[data-test-element]').hasAttribute('class', '');
+      assert
+        .dom('[data-test-element]')
+        .hasAttribute('class', '', 'We see the correct global class names.');
+    });
+
+    test('returns an empty string when there are local class names', async function (this: TestContext, assert) {
+      await render<TestContext>(hbs`
+        <div
+          {{! @glint-expect-error: We are testing a special case (styles is an empty object) }}
+          class={{local-class this.styles "container" "is-wide" "is-inline"}}
+          data-test-element
+        >
+        </div>
+      `);
+
+      assert
+        .dom('[data-test-element]')
+        .hasAttribute('class', '', 'We see the correct global class names.');
     });
   });
 });

--- a/test-app/tests/integration/helpers/local-class/styles-index-signature-parameter-test.ts
+++ b/test-app/tests/integration/helpers/local-class/styles-index-signature-parameter-test.ts
@@ -1,0 +1,60 @@
+import { TestContext as BaseTestContext } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+interface TestContext extends BaseTestContext {
+  styles: Record<string, string>;
+}
+
+module('Integration | Helper | local-class', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module(
+    'When styles has the type of index signature parameter',
+    function (nestedHooks) {
+      nestedHooks.beforeEach(function (this: TestContext) {
+        this.styles = {
+          container: 'container-hashed',
+          'is-inline': 'is-inline-hashed',
+          'is-wide': 'is-wide-hashed',
+          'no-feedback': 'no-feedback-hashed',
+        };
+      });
+
+      test('returns an empty string when there are no local class names', async function (this: TestContext, assert) {
+        await render<TestContext>(hbs`
+          <div
+            class={{local-class this.styles}}
+            data-test-element
+          >
+          </div>
+        `);
+
+        assert
+          .dom('[data-test-element]')
+          .hasAttribute('class', '', 'We see the correct global class names.');
+      });
+
+      test('returns a concatenated string when there are local class names', async function (this: TestContext, assert) {
+        await render<TestContext>(hbs`
+          <div
+            {{! @glint-expect-error: We are testing a special case (styles has an incorrect type) }}
+            class={{local-class this.styles "container" "is-wide" "is-inline"}}
+            data-test-element
+          >
+          </div>
+        `);
+
+        assert
+          .dom('[data-test-element]')
+          .hasAttribute(
+            'class',
+            'container-hashed is-wide-hashed is-inline-hashed',
+            'We see the correct global class names.'
+          );
+      });
+    }
+  );
+});

--- a/test-app/tests/integration/helpers/local-class/styles-undefined-test.ts
+++ b/test-app/tests/integration/helpers/local-class/styles-undefined-test.ts
@@ -1,0 +1,61 @@
+import { TestContext as BaseTestContext } from '@ember/test-helpers';
+import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+interface TestContext extends BaseTestContext {
+  styles: undefined;
+}
+
+module('Integration | Helper | local-class', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('When styles is undefined', function (nestedHooks) {
+    nestedHooks.beforeEach(function (this: TestContext) {
+      this.styles = undefined;
+    });
+
+    test('throws an error when there are no local class names (only in development environment)', async function (this: TestContext, assert) {
+      setupOnerror(function () {
+        // Do nothing
+      });
+
+      await render<TestContext>(hbs`
+        <div
+          {{! @glint-expect-error: We are testing a special case (styles has an incorrect type) }}
+          class={{local-class this.styles}}
+          data-test-element
+        >
+        </div>
+      `);
+
+      assert.throws(function () {
+        throw new Error('The styles object is undefined.');
+      }, 'We see the correct error message.');
+
+      resetOnerror();
+    });
+
+    test('throws an error when there are local class names (only in development environment)', async function (this: TestContext, assert) {
+      setupOnerror(function () {
+        // Do nothing
+      });
+
+      await render<TestContext>(hbs`
+        <div
+          {{! @glint-expect-error: We are testing a special case (styles has an incorrect type) }}
+          class={{local-class this.styles "container" "is-wide" "is-inline"}}
+          data-test-element
+        >
+        </div>
+      `);
+
+      assert.throws(function () {
+        throw new Error('The styles object is undefined.');
+      }, 'We see the correct error message.');
+
+      resetOnerror();
+    });
+  });
+});

--- a/test-app/tests/integration/helpers/local-class/styles-well-defined-test.ts
+++ b/test-app/tests/integration/helpers/local-class/styles-well-defined-test.ts
@@ -35,7 +35,9 @@ module('Integration | Helper | local-class', function (hooks) {
         </div>
       `);
 
-      assert.dom('[data-test-element]').hasAttribute('class', '');
+      assert
+        .dom('[data-test-element]')
+        .hasAttribute('class', '', 'We see the correct global class names.');
     });
 
     test('returns a concatenated string when there are local class names', async function (this: TestContext, assert) {
@@ -51,7 +53,8 @@ module('Integration | Helper | local-class', function (hooks) {
         .dom('[data-test-element]')
         .hasAttribute(
           'class',
-          'container-hashed is-wide-hashed is-inline-hashed'
+          'container-hashed is-wide-hashed is-inline-hashed',
+          'We see the correct global class names.'
         );
     });
   });


### PR DESCRIPTION
## Description

Until now, the tests for the `{{local-class}}` helper have assumed the ideal case, when Glint is present to ensure that the end-developer provides the right types in templates.

I updated the helper and wrote tests to document what the helper does when the end-developer provides arguments with incorrect types.