### PR TITLE
Add example style sheet in README

### DIFF
--- a/embroider-css-modules/README.md
+++ b/embroider-css-modules/README.md
@@ -42,6 +42,22 @@ ember install embroider-css-modules
 
 - If you are using `<template>` tag, you are good to go! Use the named import to consume things.
 
+    ```css
+    /* app/components/ui/page.css */
+    .container {
+      margin: 16px;
+      background-color: #FAFAFA;
+    }
+
+    .header {
+      font-size: 24px;
+      font-weight: bold;
+    }
+  
+    .body {
+      font-size: 16px;
+    }
+    ```
     ```ts
     /* app/components/ui/page.gts */
     import { localClass } from 'embroider-css-modules';


### PR DESCRIPTION
Awesome work on this!

I was going through the code example in the `embroider-css-modules` package and missed the context of the actual CSS file. To get the full picture of the addon, I had a look in the [docs app](https://github.com/ijlee2/embroider-css-modules/tree/main/docs-app).

Not sure if the `d.ts` file should be mentioned as well?

Also pretty cool that styles can be co-located and depend on module resolution. That's perhaps something that can use a further mention as well?