### PR TITLE
Refactor code (abstract syntax tree)

### DIFF
--- a/docs-app/app/components/navigation-menu.gts
+++ b/docs-app/app/components/navigation-menu.gts
@@ -9,14 +9,14 @@ type MenuItem = {
   route: string;
 };
 
-interface NavigationMenuComponentSignature {
+interface NavigationMenuSignature {
   Args: {
     menuItems: Array<MenuItem>;
     name?: string;
   };
 }
 
-const NavigationMenuComponent: TOC<NavigationMenuComponentSignature> =
+const NavigationMenuComponent: TOC<NavigationMenuSignature> =
 <template>
   <nav aria-label={{@name}} data-test-nav={{@name}}>
     <ul class={{styles.list}}>

--- a/docs-app/app/components/products/product/card.gts
+++ b/docs-app/app/components/products/product/card.gts
@@ -7,14 +7,14 @@ import type { Product } from '../../../data/products';
 import styles from './card.css';
 import ProductsProductImage from './image';
 
-interface ProductsProductCardComponentSignature {
+interface ProductsProductCardSignature {
   Args: {
     product: Product;
     redirectTo?: string;
   };
 }
 
-const ProductsProductCardComponent: TOC<ProductsProductCardComponentSignature> =
+const ProductsProductCardComponent: TOC<ProductsProductCardSignature> =
 <template>
   <ContainerQuery
     @features={{hash wide=(width min=320)}}

--- a/docs-app/app/components/products/product/image.gts
+++ b/docs-app/app/components/products/product/image.gts
@@ -5,13 +5,13 @@ import styles from './image.css';
 
 const isTestEnvironment = config.environment === 'test';
 
-interface ProductsProductImageComponentSignature {
+interface ProductsProductImageSignature {
   Args: {
     src: string;
   };
 }
 
-const ProductsProductImageComponent: TOC<ProductsProductImageComponentSignature> =
+const ProductsProductImageComponent: TOC<ProductsProductImageSignature> =
 <template>
   {{#if isTestEnvironment}}
     <div class={{styles.placeholder-image}}></div>

--- a/docs-app/app/components/ui/form.ts
+++ b/docs-app/app/components/ui/form.ts
@@ -9,7 +9,7 @@ import type UiFormCheckboxComponent from './form/checkbox';
 import type UiFormInputComponent from './form/input';
 import type UiFormTextareaComponent from './form/textarea';
 
-interface UiFormComponentSignature {
+interface UiFormSignature {
   Args: {
     data?: Record<string, any>;
     instructions?: string;
@@ -35,7 +35,7 @@ interface UiFormComponentSignature {
   };
 }
 
-export default class UiFormComponent extends Component<UiFormComponentSignature> {
+export default class UiFormComponent extends Component<UiFormSignature> {
   formId = guidFor(this);
   styles = styles;
 

--- a/docs-app/app/components/ui/form/checkbox.ts
+++ b/docs-app/app/components/ui/form/checkbox.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './checkbox.css';
 
-interface UiFormCheckboxComponentSignature {
+interface UiFormCheckboxSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormCheckboxComponentSignature {
   };
 }
 
-export default class UiFormCheckboxComponent extends Component<UiFormCheckboxComponentSignature> {
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/docs-app/app/components/ui/form/field.gts
+++ b/docs-app/app/components/ui/form/field.gts
@@ -5,7 +5,7 @@ import { localClass } from 'embroider-css-modules';
 
 import styles from './field.css';
 
-interface UiFormFieldComponentSignature {
+interface UiFormFieldSignature {
   Args: {
     errorMessage?: string;
     isInline?: boolean;
@@ -25,7 +25,7 @@ interface UiFormFieldComponentSignature {
   };
 }
 
-export default class UiFormFieldComponent extends Component<UiFormFieldComponentSignature> {
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
   inputId = guidFor(this);
 
   <template>

--- a/docs-app/app/components/ui/form/information.gts
+++ b/docs-app/app/components/ui/form/information.gts
@@ -2,7 +2,7 @@ import type { TOC } from '@ember/component/template-only';
 
 import styles from './information.css';
 
-interface UiFormInformationComponentSignature {
+interface UiFormInformationSignature {
   Args: {
     formId: string;
     instructions?: string;
@@ -14,7 +14,7 @@ function or(title?: string, instructions?: string) {
   return Boolean(title) || Boolean(instructions);
 }
 
-const UiFormInformationComponent: TOC<UiFormInformationComponentSignature> =
+const UiFormInformationComponent: TOC<UiFormInformationSignature> =
 <template>
   {{#if (or @title @instructions)}}
     <div class={{styles.container}}>

--- a/docs-app/app/components/ui/form/input.ts
+++ b/docs-app/app/components/ui/form/input.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './input.css';
 
-interface UiFormInputComponentSignature {
+interface UiFormInputSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -18,7 +18,7 @@ interface UiFormInputComponentSignature {
   };
 }
 
-export default class UiFormInputComponent extends Component<UiFormInputComponentSignature> {
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/docs-app/app/components/ui/form/textarea.ts
+++ b/docs-app/app/components/ui/form/textarea.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './textarea.css';
 
-interface UiFormTextareaComponentSignature {
+interface UiFormTextareaSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormTextareaComponentSignature {
   };
 }
 
-export default class UiFormTextareaComponent extends Component<UiFormTextareaComponentSignature> {
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/docs-app/app/components/ui/page.gts
+++ b/docs-app/app/components/ui/page.gts
@@ -3,7 +3,7 @@ import { localClass } from 'embroider-css-modules';
 
 import styles from './page.css';
 
-interface UiPageComponentSignature {
+interface UiPageSignature {
   Args: {
     title: string;
   };
@@ -12,7 +12,7 @@ interface UiPageComponentSignature {
   };
 }
 
-const UiPageComponent: TOC<UiPageComponentSignature> =
+const UiPageComponent: TOC<UiPageSignature> =
 <template>
   <div class={{localClass styles "container"}}>
     <h1 class={{styles.header}}>

--- a/ember-codemod-remove-ember-css-modules/src/utils/abstract-syntax-tree/javascript.js
+++ b/ember-codemod-remove-ember-css-modules/src/utils/abstract-syntax-tree/javascript.js
@@ -71,29 +71,25 @@ const tsOptions = {
 };
 
 function getParseOptions(hasTypeScript) {
+  const options = hasTypeScript ? tsOptions : jsOptions;
+
   return {
     parser: {
       parse(file) {
-        return babelParser(file, hasTypeScript ? tsOptions : jsOptions);
+        return babelParser(file, options);
       },
     },
   };
 }
 
-function traverseJavaScript(file, visitMethods) {
-  const ast = parse(file, getParseOptions(false));
+function traverse(hasTypeScript) {
+  return function (file, visitMethods) {
+    const ast = parse(file, getParseOptions(hasTypeScript));
 
-  visit(ast, visitMethods);
+    visit(ast, visitMethods);
 
-  return ast;
-}
-
-function traverseTypeScript(file, visitMethods) {
-  const ast = parse(file, getParseOptions(true));
-
-  visit(ast, visitMethods);
-
-  return ast;
+    return ast;
+  };
 }
 
 const tools = {
@@ -101,9 +97,7 @@ const tools = {
   print(ast) {
     return print(ast, formattingOptions).code;
   },
-  traverse(hasTypeScript) {
-    return hasTypeScript ? traverseTypeScript : traverseJavaScript;
-  },
+  traverse,
 };
 
 export default tools;

--- a/ember-codemod-remove-ember-css-modules/tests/utils/blueprints/process-template/evaluate.test.js
+++ b/ember-codemod-remove-ember-css-modules/tests/utils/blueprints/process-template/evaluate.test.js
@@ -5,7 +5,7 @@ test('utils | blueprints | process-template > evaluate', function () {
   const blueprintFile = [
     `import Component from '@glimmer/component';`,
     ``,
-    `<% if (options.packages.app.hasTypeScript) { %>export default class NavigationMenuComponent extends Component<NavigationMenuComponentSignature> {}`,
+    `<% if (options.packages.app.hasTypeScript) { %>export default class NavigationMenuComponent extends Component<NavigationMenuSignature> {}`,
     `<% } else { %>export default class NavigationMenuComponent extends Component {}`,
     `<% } %>`,
   ].join('\n');
@@ -23,7 +23,7 @@ test('utils | blueprints | process-template > evaluate', function () {
   const expectedValue = [
     `import Component from '@glimmer/component';`,
     ``,
-    `export default class NavigationMenuComponent extends Component<NavigationMenuComponentSignature> {}`,
+    `export default class NavigationMenuComponent extends Component<NavigationMenuSignature> {}`,
     ``,
   ].join('\n');
 

--- a/ember-codemod-remove-ember-css-modules/tests/utils/blueprints/process-template/interpolate.test.js
+++ b/ember-codemod-remove-ember-css-modules/tests/utils/blueprints/process-template/interpolate.test.js
@@ -3,7 +3,7 @@ import { assert, test } from '../../../helpers/testing.js';
 
 test('utils | blueprints | process-template > interpolate', function () {
   const blueprintFile = [
-    `export default class <%= componentName %>Component extends Component<<%= componentName %>ComponentSignature> {}`,
+    `export default class <%= componentName %>Component extends Component<<%= componentName %>Signature> {}`,
   ].join('\n');
 
   const file = processTemplate(blueprintFile, {
@@ -11,7 +11,7 @@ test('utils | blueprints | process-template > interpolate', function () {
   });
 
   const expectedValue = [
-    `export default class NavigationMenuComponent extends Component<NavigationMenuComponentSignature> {}`,
+    `export default class NavigationMenuComponent extends Component<NavigationMenuSignature> {}`,
   ].join('\n');
 
   assert.strictEqual(file, expectedValue);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,9 +537,6 @@ importers:
       glob:
         specifier: ^10.0.0
         version: 10.0.0
-      postcss:
-        specifier: ^8.4.21
-        version: 8.4.21
       yargs:
         specifier: ^17.7.1
         version: 17.7.1
@@ -11498,6 +11495,7 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: true
 
   /nanomatch@1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -12146,6 +12144,7 @@ packages:
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: true
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -12316,6 +12315,7 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
 
   /preferred-pm@3.0.3:
     resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,6 +537,9 @@ importers:
       glob:
         specifier: ^10.0.0
         version: 10.0.0
+      postcss:
+        specifier: ^8.4.21
+        version: 8.4.21
       yargs:
         specifier: ^17.7.1
         version: 17.7.1
@@ -11495,7 +11498,6 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /nanomatch@1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -12144,7 +12146,6 @@ packages:
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-    dev: true
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -12315,7 +12316,6 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /preferred-pm@3.0.3:
     resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}

--- a/type-css-modules/package.json
+++ b/type-css-modules/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "css-tree": "^2.3.1",
     "glob": "^10.0.0",
+    "postcss": "^8.4.21",
     "yargs": "^17.7.1"
   },
   "devDependencies": {

--- a/type-css-modules/package.json
+++ b/type-css-modules/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "css-tree": "^2.3.1",
     "glob": "^10.0.0",
-    "postcss": "^8.4.21",
     "yargs": "^17.7.1"
   },
   "devDependencies": {

--- a/type-css-modules/src/utils/abstract-syntax-tree.js
+++ b/type-css-modules/src/utils/abstract-syntax-tree.js
@@ -1,0 +1,1 @@
+export { default as ASTCSS } from './abstract-syntax-tree/css.js';

--- a/type-css-modules/src/utils/abstract-syntax-tree/css.js
+++ b/type-css-modules/src/utils/abstract-syntax-tree/css.js
@@ -1,26 +1,21 @@
-import postcss from 'postcss';
-
-function print(lazyResult) {
-  return lazyResult.css;
-}
+import { generate, parse, walk } from 'css-tree';
 
 function traverse(file, visitMethods = {}) {
-  const plugins = [
-    {
-      postcssPlugin: 'Plugin',
-      ...visitMethods,
-    },
-  ];
+  const ast = parse(file);
 
-  const processor = postcss(plugins);
-  const lazyResult = processor.process(file);
+  for (const [nodeType, visitMethod] of Object.entries(visitMethods)) {
+    walk(ast, {
+      enter: visitMethod,
+      visit: nodeType,
+    });
+  }
 
-  return lazyResult;
+  return ast;
 }
 
 const tools = {
   builders: undefined,
-  print,
+  print: generate,
   traverse,
 };
 

--- a/type-css-modules/src/utils/abstract-syntax-tree/css.js
+++ b/type-css-modules/src/utils/abstract-syntax-tree/css.js
@@ -1,21 +1,26 @@
-import { generate, parse, walk } from 'css-tree';
+import postcss from 'postcss';
+
+function print(lazyResult) {
+  return lazyResult.css;
+}
 
 function traverse(file, visitMethods = {}) {
-  const ast = parse(file);
+  const plugins = [
+    {
+      postcssPlugin: 'Plugin',
+      ...visitMethods,
+    },
+  ];
 
-  for (const [nodeType, visitMethod] of Object.entries(visitMethods)) {
-    walk(ast, {
-      enter: visitMethod,
-      visit: nodeType,
-    });
-  }
+  const processor = postcss(plugins);
+  const lazyResult = processor.process(file);
 
-  return ast;
+  return lazyResult;
 }
 
 const tools = {
   builders: undefined,
-  print: generate,
+  print,
   traverse,
 };
 

--- a/type-css-modules/src/utils/abstract-syntax-tree/css.js
+++ b/type-css-modules/src/utils/abstract-syntax-tree/css.js
@@ -1,0 +1,22 @@
+import { generate, parse, walk } from 'css-tree';
+
+function traverse(file, visitMethods = {}) {
+  const ast = parse(file);
+
+  for (const [nodeType, visitMethod] of Object.entries(visitMethods)) {
+    walk(ast, {
+      enter: visitMethod,
+      visit: nodeType,
+    });
+  }
+
+  return ast;
+}
+
+const tools = {
+  builders: undefined,
+  print: generate,
+  traverse,
+};
+
+export default tools;

--- a/type-css-modules/src/utils/css/get-class-names.js
+++ b/type-css-modules/src/utils/css/get-class-names.js
@@ -9,19 +9,25 @@ export function getClassNames(filePath, options) {
 
   const classNames = new Set();
 
-  AST.traverse(file, {
-    ClassSelector(node) {
-      classNames.add(node.name);
-    },
+  const ast = AST.traverse(file, {
+    Rule(node) {
+      console.log(node.selectors);
 
-    PseudoClassSelector(node) {
-      if (node.name === 'local') {
-        console.warn(
-          `WARNING: type-css-modules assumes that all user-defined classes are local. Consider removing the pseudo-class :local() in \`${filePath}\`.\n`
-        );
-      }
+      const selectors = node.selector.split(/\s+/);
+
+      selectors.forEach((selector) => {
+        if (!selector.startsWith('.')) {
+          return;
+        }
+
+        const classSelector = selector.replace(/^\./, '');
+
+        classNames.add(classSelector);
+      });
     },
   });
+
+  AST.print(ast);
 
   return [...classNames].sort();
 }

--- a/type-css-modules/src/utils/css/get-class-names.js
+++ b/type-css-modules/src/utils/css/get-class-names.js
@@ -1,33 +1,26 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { parse, walk } from 'css-tree';
+import { ASTCSS as AST } from '../abstract-syntax-tree.js';
 
 export function getClassNames(filePath, options) {
   const { projectRoot } = options;
-  const cssFile = readFileSync(join(projectRoot, filePath), 'utf8');
+  const file = readFileSync(join(projectRoot, filePath), 'utf8');
 
-  const ast = parse(cssFile);
   const classNames = new Set();
 
-  walk(ast, (node) => {
-    switch (node.type) {
-      case 'ClassSelector': {
-        classNames.add(node.name);
+  AST.traverse(file, {
+    ClassSelector(node) {
+      classNames.add(node.name);
+    },
 
-        break;
+    PseudoClassSelector(node) {
+      if (node.name === 'local') {
+        console.warn(
+          `WARNING: type-css-modules assumes that all user-defined classes are local. Consider removing the pseudo-class :local() in \`${filePath}\`.\n`
+        );
       }
-
-      case 'PseudoClassSelector': {
-        if (node.name === 'local') {
-          console.warn(
-            `WARNING: type-css-modules assumes that all user-defined classes are local. Consider removing the pseudo-class :local() in \`${filePath}\`.\n`
-          );
-        }
-
-        break;
-      }
-    }
+    },
   });
 
   return [...classNames].sort();

--- a/type-css-modules/src/utils/css/get-class-names.js
+++ b/type-css-modules/src/utils/css/get-class-names.js
@@ -9,25 +9,19 @@ export function getClassNames(filePath, options) {
 
   const classNames = new Set();
 
-  const ast = AST.traverse(file, {
-    Rule(node) {
-      console.log(node.selectors);
+  AST.traverse(file, {
+    ClassSelector(node) {
+      classNames.add(node.name);
+    },
 
-      const selectors = node.selector.split(/\s+/);
-
-      selectors.forEach((selector) => {
-        if (!selector.startsWith('.')) {
-          return;
-        }
-
-        const classSelector = selector.replace(/^\./, '');
-
-        classNames.add(classSelector);
-      });
+    PseudoClassSelector(node) {
+      if (node.name === 'local') {
+        console.warn(
+          `WARNING: type-css-modules assumes that all user-defined classes are local. Consider removing the pseudo-class :local() in \`${filePath}\`.\n`
+        );
+      }
     },
   });
-
-  AST.print(ast);
 
   return [...classNames].sort();
 }

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/navigation-menu.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/navigation-menu.ts
@@ -7,14 +7,14 @@ type MenuItem = {
   route: string;
 };
 
-interface NavigationMenuComponentSignature {
+interface NavigationMenuSignature {
   Args: {
     menuItems: Array<MenuItem>;
     name?: string;
   };
 }
 
-export default class NavigationMenuComponent extends Component<NavigationMenuComponentSignature> {
+export default class NavigationMenuComponent extends Component<NavigationMenuSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/products/product/card.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/products/product/card.ts
@@ -3,14 +3,14 @@ import Component from '@glimmer/component';
 import type { Product } from '../../../data/products';
 import styles from './card.css';
 
-interface ProductsProductCardComponentSignature {
+interface ProductsProductCardSignature {
   Args: {
     product: Product;
     redirectTo?: string;
   };
 }
 
-export default class ProductsProductCardComponent extends Component<ProductsProductCardComponentSignature> {
+export default class ProductsProductCardComponent extends Component<ProductsProductCardSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/products/product/image.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/products/product/image.ts
@@ -3,13 +3,13 @@ import config from 'docs-app/config/environment';
 
 import styles from './image.css';
 
-interface ProductsProductImageComponentSignature {
+interface ProductsProductImageSignature {
   Args: {
     src: string;
   };
 }
 
-export default class ProductsProductImageComponent extends Component<ProductsProductImageComponentSignature> {
+export default class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
   styles = styles;
 
   get isTestEnvironment() {

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/tracks.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/tracks.ts
@@ -2,13 +2,13 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 import type { Track } from '../data/album';
 
-interface TracksComponentSignature {
+interface TracksSignature {
   Args: {
     tracks?: Array<Track>;
   };
 }
 
-const TracksComponent = templateOnlyComponent<TracksComponentSignature>();
+const TracksComponent = templateOnlyComponent<TracksSignature>();
 
 export default TracksComponent;
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/tracks/list.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/tracks/list.ts
@@ -3,14 +3,14 @@ import Component from '@glimmer/component';
 import type { Track } from '../../data/album';
 import styles from './list.css';
 
-interface TracksListComponentSignature {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Array<Track>;
   };
 }
 
-export default class TracksListComponent extends Component<TracksListComponentSignature> {
+export default class TracksListComponent extends Component<TracksListSignature> {
   styles = styles;
 
   get numColumns(): number {

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/tracks/table.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/tracks/table.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Track } from '../../data/album';
 import styles from './table.css';
 
-interface TracksTableComponentSignature {
+interface TracksTableSignature {
   Args: {
     tracks?: Array<Track>;
   };
 }
 
-export default class TracksTableComponent extends Component<TracksTableComponentSignature> {
+export default class TracksTableComponent extends Component<TracksTableSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form.ts
@@ -9,7 +9,7 @@ import type UiFormCheckboxComponent from './form/checkbox';
 import type UiFormInputComponent from './form/input';
 import type UiFormTextareaComponent from './form/textarea';
 
-interface UiFormComponentSignature {
+interface UiFormSignature {
   Args: {
     data?: Record<string, any>;
     instructions?: string;
@@ -35,7 +35,7 @@ interface UiFormComponentSignature {
   };
 }
 
-export default class UiFormComponent extends Component<UiFormComponentSignature> {
+export default class UiFormComponent extends Component<UiFormSignature> {
   formId = guidFor(this);
   styles = styles;
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/checkbox.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/checkbox.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './checkbox.css';
 
-interface UiFormCheckboxComponentSignature {
+interface UiFormCheckboxSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormCheckboxComponentSignature {
   };
 }
 
-export default class UiFormCheckboxComponent extends Component<UiFormCheckboxComponentSignature> {
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/field.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/field.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './field.css';
 
-interface UiFormFieldComponentSignature {
+interface UiFormFieldSignature {
   Args: {
     errorMessage?: string;
     isInline?: boolean;
@@ -23,7 +23,7 @@ interface UiFormFieldComponentSignature {
   };
 }
 
-export default class UiFormFieldComponent extends Component<UiFormFieldComponentSignature> {
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
   inputId = guidFor(this);
   styles = styles;
 }

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/information.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/information.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import styles from './information.css';
 
-interface UiFormInformationComponentSignature {
+interface UiFormInformationSignature {
   Args: {
     formId: string;
     instructions?: string;
@@ -10,7 +10,7 @@ interface UiFormInformationComponentSignature {
   };
 }
 
-export default class UiFormInformationComponent extends Component<UiFormInformationComponentSignature> {
+export default class UiFormInformationComponent extends Component<UiFormInformationSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/input.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/input.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './input.css';
 
-interface UiFormInputComponentSignature {
+interface UiFormInputSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -18,7 +18,7 @@ interface UiFormInputComponentSignature {
   };
 }
 
-export default class UiFormInputComponent extends Component<UiFormInputComponentSignature> {
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/textarea.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/form/textarea.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './textarea.css';
 
-interface UiFormTextareaComponentSignature {
+interface UiFormTextareaSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormTextareaComponentSignature {
   };
 }
 
-export default class UiFormTextareaComponent extends Component<UiFormTextareaComponentSignature> {
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/page.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/ui/page.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import styles from './page.css';
 
-interface UiPageComponentSignature {
+interface UiPageSignature {
   Args: {
     title: string;
   };
@@ -11,7 +11,7 @@ interface UiPageComponentSignature {
   };
 }
 
-export default class UiPageComponent extends Component<UiPageComponentSignature> {
+export default class UiPageComponent extends Component<UiPageSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-1.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-1.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './widget-1.css';
 
-interface WidgetsWidget1ComponentSignature {}
+interface WidgetsWidget1Signature {}
 
-export default class WidgetsWidget1Component extends Component<WidgetsWidget1ComponentSignature> {
+export default class WidgetsWidget1Component extends Component<WidgetsWidget1Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-1/item.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-1/item.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './item.css';
 
-interface WidgetsWidget1ItemComponentSignature {
+interface WidgetsWidget1ItemSignature {
   Args: {
     title: string;
   };
 }
 
-export default class WidgetsWidget1ItemComponent extends Component<WidgetsWidget1ItemComponentSignature> {
+export default class WidgetsWidget1ItemComponent extends Component<WidgetsWidget1ItemSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-2.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-2.ts
@@ -9,16 +9,16 @@ import {
 } from '../../utils/components/widgets/widget-2';
 import styles from './widget-2.css';
 
-interface WidgetsWidget2ComponentSignature {}
+interface WidgetsWidget2Signature {}
 
-export default class WidgetsWidget2Component extends Component<WidgetsWidget2ComponentSignature> {
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
   styles = styles;
 
   @tracked data = [] as Array<Data>;
   @tracked summaries = [] as Array<Summary>;
 
-  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget2ComponentSignature' */
-  constructor(owner: unknown, args: WidgetsWidget2ComponentSignature['Args']) {
+  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget2Signature' */
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-2/captions.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-2/captions.ts
@@ -5,13 +5,13 @@ import { tracked } from '@glimmer/tracking';
 import type { Summary } from '../../../utils/components/widgets/widget-2';
 import styles from './captions.css';
 
-interface WidgetsWidget2CaptionsComponentSignature {
+interface WidgetsWidget2CaptionsSignature {
   Args: {
     summaries?: Array<Summary>;
   };
 }
 
-export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsComponentSignature> {
+export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {
   styles = styles;
 
   @tracked currentIndex = 0;

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-2/stacked-chart.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-2/stacked-chart.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Data } from '../../../utils/components/widgets/widget-2';
 import styles from './stacked-chart.css';
 
-interface WidgetsWidget2StackedChartComponentSignature {
+interface WidgetsWidget2StackedChartSignature {
   Args: {
     data: Array<Data>;
   };
 }
 
-export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartComponentSignature> {
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-3.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-3.ts
@@ -5,15 +5,15 @@ import type { Concert } from '../../data/concert';
 import concertData from '../../data/concert';
 import styles from './widget-3.css';
 
-interface WidgetsWidget3ComponentSignature {}
+interface WidgetsWidget3Signature {}
 
-export default class WidgetsWidget3Component extends Component<WidgetsWidget3ComponentSignature> {
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
   styles = styles;
 
   @tracked concertData = {} as Concert;
 
-  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget3ComponentSignature' */
-  constructor(owner: unknown, args: WidgetsWidget3ComponentSignature['Args']) {
+  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget3Signature' */
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-3/tour-schedule.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-3/tour-schedule.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Concert } from '../../../data/concert';
 import styles from './tour-schedule.css';
 
-interface WidgetsWidget3TourScheduleComponentSignature {
+interface WidgetsWidget3TourScheduleSignature {
   Args: {
     concert: Concert;
   };
 }
 
-export default class WidgetsWidget3TourScheduleComponent extends Component<WidgetsWidget3TourScheduleComponentSignature> {
+export default class WidgetsWidget3TourScheduleComponent extends Component<WidgetsWidget3TourScheduleSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -7,13 +7,13 @@ import type { Image } from '../../../../data/concert';
 import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
 import styles from './responsive-image.css';
 
-interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
   Args: {
     images: Array<Image>;
   };
 }
 
-export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentSignature> {
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
   styles = styles;
 
   @tracked imageSource?: string;

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './widget-4.css';
 
-interface WidgetsWidget4ComponentSignature {}
+interface WidgetsWidget4Signature {}
 
-export default class WidgetsWidget4Component extends Component<WidgetsWidget4ComponentSignature> {
+export default class WidgetsWidget4Component extends Component<WidgetsWidget4Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4/memo.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4/memo.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './memo.css';
 
-interface WidgetsWidget4MemoComponentSignature {}
+interface WidgetsWidget4MemoSignature {}
 
-export default class WidgetsWidget4MemoComponent extends Component<WidgetsWidget4MemoComponentSignature> {
+export default class WidgetsWidget4MemoComponent extends Component<WidgetsWidget4MemoSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4/memo/actions.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4/memo/actions.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './actions.css';
 
-interface WidgetsWidget4MemoActionsComponentSignature {
+interface WidgetsWidget4MemoActionsSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoActionsComponent extends Component<WidgetsWidget4MemoActionsComponentSignature> {
+export default class WidgetsWidget4MemoActionsComponent extends Component<WidgetsWidget4MemoActionsSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4/memo/body.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4/memo/body.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './body.css';
 
-interface WidgetsWidget4MemoBodyComponentSignature {
+interface WidgetsWidget4MemoBodySignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoBodyComponent extends Component<WidgetsWidget4MemoBodyComponentSignature> {
+export default class WidgetsWidget4MemoBodyComponent extends Component<WidgetsWidget4MemoBodySignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4/memo/header.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-4/memo/header.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './header.css';
 
-interface WidgetsWidget4MemoHeaderComponentSignature {
+interface WidgetsWidget4MemoHeaderSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoHeaderComponent extends Component<WidgetsWidget4MemoHeaderComponentSignature> {
+export default class WidgetsWidget4MemoHeaderComponent extends Component<WidgetsWidget4MemoHeaderSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-5.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/input/app/components/widgets/widget-5.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './widget-5.css';
 
-interface WidgetsWidget5ComponentSignature {}
+interface WidgetsWidget5Signature {}
 
-export default class WidgetsWidget5Component extends Component<WidgetsWidget5ComponentSignature> {
+export default class WidgetsWidget5Component extends Component<WidgetsWidget5Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/navigation-menu.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/navigation-menu.ts
@@ -7,14 +7,14 @@ type MenuItem = {
   route: string;
 };
 
-interface NavigationMenuComponentSignature {
+interface NavigationMenuSignature {
   Args: {
     menuItems: Array<MenuItem>;
     name?: string;
   };
 }
 
-export default class NavigationMenuComponent extends Component<NavigationMenuComponentSignature> {
+export default class NavigationMenuComponent extends Component<NavigationMenuSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/products/product/card.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/products/product/card.ts
@@ -3,14 +3,14 @@ import Component from '@glimmer/component';
 import type { Product } from '../../../data/products';
 import styles from './card.css';
 
-interface ProductsProductCardComponentSignature {
+interface ProductsProductCardSignature {
   Args: {
     product: Product;
     redirectTo?: string;
   };
 }
 
-export default class ProductsProductCardComponent extends Component<ProductsProductCardComponentSignature> {
+export default class ProductsProductCardComponent extends Component<ProductsProductCardSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/products/product/image.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/products/product/image.ts
@@ -3,13 +3,13 @@ import config from 'docs-app/config/environment';
 
 import styles from './image.css';
 
-interface ProductsProductImageComponentSignature {
+interface ProductsProductImageSignature {
   Args: {
     src: string;
   };
 }
 
-export default class ProductsProductImageComponent extends Component<ProductsProductImageComponentSignature> {
+export default class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
   styles = styles;
 
   get isTestEnvironment() {

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/tracks.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/tracks.ts
@@ -2,13 +2,13 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 import type { Track } from '../data/album';
 
-interface TracksComponentSignature {
+interface TracksSignature {
   Args: {
     tracks?: Array<Track>;
   };
 }
 
-const TracksComponent = templateOnlyComponent<TracksComponentSignature>();
+const TracksComponent = templateOnlyComponent<TracksSignature>();
 
 export default TracksComponent;
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/tracks/list.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/tracks/list.ts
@@ -3,14 +3,14 @@ import Component from '@glimmer/component';
 import type { Track } from '../../data/album';
 import styles from './list.css';
 
-interface TracksListComponentSignature {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Array<Track>;
   };
 }
 
-export default class TracksListComponent extends Component<TracksListComponentSignature> {
+export default class TracksListComponent extends Component<TracksListSignature> {
   styles = styles;
 
   get numColumns(): number {

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/tracks/table.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/tracks/table.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Track } from '../../data/album';
 import styles from './table.css';
 
-interface TracksTableComponentSignature {
+interface TracksTableSignature {
   Args: {
     tracks?: Array<Track>;
   };
 }
 
-export default class TracksTableComponent extends Component<TracksTableComponentSignature> {
+export default class TracksTableComponent extends Component<TracksTableSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form.ts
@@ -9,7 +9,7 @@ import type UiFormCheckboxComponent from './form/checkbox';
 import type UiFormInputComponent from './form/input';
 import type UiFormTextareaComponent from './form/textarea';
 
-interface UiFormComponentSignature {
+interface UiFormSignature {
   Args: {
     data?: Record<string, any>;
     instructions?: string;
@@ -35,7 +35,7 @@ interface UiFormComponentSignature {
   };
 }
 
-export default class UiFormComponent extends Component<UiFormComponentSignature> {
+export default class UiFormComponent extends Component<UiFormSignature> {
   formId = guidFor(this);
   styles = styles;
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/checkbox.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/checkbox.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './checkbox.css';
 
-interface UiFormCheckboxComponentSignature {
+interface UiFormCheckboxSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormCheckboxComponentSignature {
   };
 }
 
-export default class UiFormCheckboxComponent extends Component<UiFormCheckboxComponentSignature> {
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/field.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/field.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './field.css';
 
-interface UiFormFieldComponentSignature {
+interface UiFormFieldSignature {
   Args: {
     errorMessage?: string;
     isInline?: boolean;
@@ -23,7 +23,7 @@ interface UiFormFieldComponentSignature {
   };
 }
 
-export default class UiFormFieldComponent extends Component<UiFormFieldComponentSignature> {
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
   inputId = guidFor(this);
   styles = styles;
 }

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/information.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/information.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import styles from './information.css';
 
-interface UiFormInformationComponentSignature {
+interface UiFormInformationSignature {
   Args: {
     formId: string;
     instructions?: string;
@@ -10,7 +10,7 @@ interface UiFormInformationComponentSignature {
   };
 }
 
-export default class UiFormInformationComponent extends Component<UiFormInformationComponentSignature> {
+export default class UiFormInformationComponent extends Component<UiFormInformationSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/input.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/input.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './input.css';
 
-interface UiFormInputComponentSignature {
+interface UiFormInputSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -18,7 +18,7 @@ interface UiFormInputComponentSignature {
   };
 }
 
-export default class UiFormInputComponent extends Component<UiFormInputComponentSignature> {
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/textarea.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/form/textarea.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './textarea.css';
 
-interface UiFormTextareaComponentSignature {
+interface UiFormTextareaSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormTextareaComponentSignature {
   };
 }
 
-export default class UiFormTextareaComponent extends Component<UiFormTextareaComponentSignature> {
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/page.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/ui/page.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import styles from './page.css';
 
-interface UiPageComponentSignature {
+interface UiPageSignature {
   Args: {
     title: string;
   };
@@ -11,7 +11,7 @@ interface UiPageComponentSignature {
   };
 }
 
-export default class UiPageComponent extends Component<UiPageComponentSignature> {
+export default class UiPageComponent extends Component<UiPageSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-1.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-1.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './widget-1.css';
 
-interface WidgetsWidget1ComponentSignature {}
+interface WidgetsWidget1Signature {}
 
-export default class WidgetsWidget1Component extends Component<WidgetsWidget1ComponentSignature> {
+export default class WidgetsWidget1Component extends Component<WidgetsWidget1Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-1/item.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-1/item.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './item.css';
 
-interface WidgetsWidget1ItemComponentSignature {
+interface WidgetsWidget1ItemSignature {
   Args: {
     title: string;
   };
 }
 
-export default class WidgetsWidget1ItemComponent extends Component<WidgetsWidget1ItemComponentSignature> {
+export default class WidgetsWidget1ItemComponent extends Component<WidgetsWidget1ItemSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-2.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-2.ts
@@ -9,16 +9,16 @@ import {
 } from '../../utils/components/widgets/widget-2';
 import styles from './widget-2.css';
 
-interface WidgetsWidget2ComponentSignature {}
+interface WidgetsWidget2Signature {}
 
-export default class WidgetsWidget2Component extends Component<WidgetsWidget2ComponentSignature> {
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
   styles = styles;
 
   @tracked data = [] as Array<Data>;
   @tracked summaries = [] as Array<Summary>;
 
-  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget2ComponentSignature' */
-  constructor(owner: unknown, args: WidgetsWidget2ComponentSignature['Args']) {
+  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget2Signature' */
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-2/captions.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-2/captions.ts
@@ -5,13 +5,13 @@ import { tracked } from '@glimmer/tracking';
 import type { Summary } from '../../../utils/components/widgets/widget-2';
 import styles from './captions.css';
 
-interface WidgetsWidget2CaptionsComponentSignature {
+interface WidgetsWidget2CaptionsSignature {
   Args: {
     summaries?: Array<Summary>;
   };
 }
 
-export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsComponentSignature> {
+export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {
   styles = styles;
 
   @tracked currentIndex = 0;

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Data } from '../../../utils/components/widgets/widget-2';
 import styles from './stacked-chart.css';
 
-interface WidgetsWidget2StackedChartComponentSignature {
+interface WidgetsWidget2StackedChartSignature {
   Args: {
     data: Array<Data>;
   };
 }
 
-export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartComponentSignature> {
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-3.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-3.ts
@@ -5,15 +5,15 @@ import type { Concert } from '../../data/concert';
 import concertData from '../../data/concert';
 import styles from './widget-3.css';
 
-interface WidgetsWidget3ComponentSignature {}
+interface WidgetsWidget3Signature {}
 
-export default class WidgetsWidget3Component extends Component<WidgetsWidget3ComponentSignature> {
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
   styles = styles;
 
   @tracked concertData = {} as Concert;
 
-  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget3ComponentSignature' */
-  constructor(owner: unknown, args: WidgetsWidget3ComponentSignature['Args']) {
+  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget3Signature' */
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Concert } from '../../../data/concert';
 import styles from './tour-schedule.css';
 
-interface WidgetsWidget3TourScheduleComponentSignature {
+interface WidgetsWidget3TourScheduleSignature {
   Args: {
     concert: Concert;
   };
 }
 
-export default class WidgetsWidget3TourScheduleComponent extends Component<WidgetsWidget3TourScheduleComponentSignature> {
+export default class WidgetsWidget3TourScheduleComponent extends Component<WidgetsWidget3TourScheduleSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -7,13 +7,13 @@ import type { Image } from '../../../../data/concert';
 import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
 import styles from './responsive-image.css';
 
-interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
   Args: {
     images: Array<Image>;
   };
 }
 
-export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentSignature> {
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
   styles = styles;
 
   @tracked imageSource?: string;

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './widget-4.css';
 
-interface WidgetsWidget4ComponentSignature {}
+interface WidgetsWidget4Signature {}
 
-export default class WidgetsWidget4Component extends Component<WidgetsWidget4ComponentSignature> {
+export default class WidgetsWidget4Component extends Component<WidgetsWidget4Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4/memo.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4/memo.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './memo.css';
 
-interface WidgetsWidget4MemoComponentSignature {}
+interface WidgetsWidget4MemoSignature {}
 
-export default class WidgetsWidget4MemoComponent extends Component<WidgetsWidget4MemoComponentSignature> {
+export default class WidgetsWidget4MemoComponent extends Component<WidgetsWidget4MemoSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4/memo/actions.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './actions.css';
 
-interface WidgetsWidget4MemoActionsComponentSignature {
+interface WidgetsWidget4MemoActionsSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoActionsComponent extends Component<WidgetsWidget4MemoActionsComponentSignature> {
+export default class WidgetsWidget4MemoActionsComponent extends Component<WidgetsWidget4MemoActionsSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4/memo/body.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4/memo/body.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './body.css';
 
-interface WidgetsWidget4MemoBodyComponentSignature {
+interface WidgetsWidget4MemoBodySignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoBodyComponent extends Component<WidgetsWidget4MemoBodyComponentSignature> {
+export default class WidgetsWidget4MemoBodyComponent extends Component<WidgetsWidget4MemoBodySignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4/memo/header.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-4/memo/header.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './header.css';
 
-interface WidgetsWidget4MemoHeaderComponentSignature {
+interface WidgetsWidget4MemoHeaderSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoHeaderComponent extends Component<WidgetsWidget4MemoHeaderComponentSignature> {
+export default class WidgetsWidget4MemoHeaderComponent extends Component<WidgetsWidget4MemoHeaderSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-5.ts
+++ b/type-css-modules/tests/fixtures/ember-app-flat/output/app/components/widgets/widget-5.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './widget-5.css';
 
-interface WidgetsWidget5ComponentSignature {}
+interface WidgetsWidget5Signature {}
 
-export default class WidgetsWidget5Component extends Component<WidgetsWidget5ComponentSignature> {
+export default class WidgetsWidget5Component extends Component<WidgetsWidget5Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/navigation-menu/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/navigation-menu/index.ts
@@ -7,14 +7,14 @@ type MenuItem = {
   route: string;
 };
 
-interface NavigationMenuComponentSignature {
+interface NavigationMenuSignature {
   Args: {
     menuItems: Array<MenuItem>;
     name?: string;
   };
 }
 
-export default class NavigationMenuComponent extends Component<NavigationMenuComponentSignature> {
+export default class NavigationMenuComponent extends Component<NavigationMenuSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/products/product/card/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/products/product/card/index.ts
@@ -3,14 +3,14 @@ import Component from '@glimmer/component';
 import type { Product } from '../../../../data/products';
 import styles from './index.css';
 
-interface ProductsProductCardComponentSignature {
+interface ProductsProductCardSignature {
   Args: {
     product: Product;
     redirectTo?: string;
   };
 }
 
-export default class ProductsProductCardComponent extends Component<ProductsProductCardComponentSignature> {
+export default class ProductsProductCardComponent extends Component<ProductsProductCardSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/products/product/image/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/products/product/image/index.ts
@@ -3,13 +3,13 @@ import config from 'docs-app/config/environment';
 
 import styles from './index.css';
 
-interface ProductsProductImageComponentSignature {
+interface ProductsProductImageSignature {
   Args: {
     src: string;
   };
 }
 
-export default class ProductsProductImageComponent extends Component<ProductsProductImageComponentSignature> {
+export default class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
   styles = styles;
 
   get isTestEnvironment() {

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/tracks/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/tracks/index.ts
@@ -2,13 +2,13 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 import type { Track } from '../../data/album';
 
-interface TracksComponentSignature {
+interface TracksSignature {
   Args: {
     tracks?: Array<Track>;
   };
 }
 
-const TracksComponent = templateOnlyComponent<TracksComponentSignature>();
+const TracksComponent = templateOnlyComponent<TracksSignature>();
 
 export default TracksComponent;
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/tracks/list/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/tracks/list/index.ts
@@ -3,14 +3,14 @@ import Component from '@glimmer/component';
 import type { Track } from '../../../data/album';
 import styles from './index.css';
 
-interface TracksListComponentSignature {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Array<Track>;
   };
 }
 
-export default class TracksListComponent extends Component<TracksListComponentSignature> {
+export default class TracksListComponent extends Component<TracksListSignature> {
   styles = styles;
 
   get numColumns(): number {

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/tracks/table/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/tracks/table/index.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Track } from '../../../data/album';
 import styles from './index.css';
 
-interface TracksTableComponentSignature {
+interface TracksTableSignature {
   Args: {
     tracks?: Array<Track>;
   };
 }
 
-export default class TracksTableComponent extends Component<TracksTableComponentSignature> {
+export default class TracksTableComponent extends Component<TracksTableSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/checkbox/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/checkbox/index.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormCheckboxComponentSignature {
+interface UiFormCheckboxSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormCheckboxComponentSignature {
   };
 }
 
-export default class UiFormCheckboxComponent extends Component<UiFormCheckboxComponentSignature> {
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/field/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/field/index.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormFieldComponentSignature {
+interface UiFormFieldSignature {
   Args: {
     errorMessage?: string;
     isInline?: boolean;
@@ -23,7 +23,7 @@ interface UiFormFieldComponentSignature {
   };
 }
 
-export default class UiFormFieldComponent extends Component<UiFormFieldComponentSignature> {
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
   inputId = guidFor(this);
   styles = styles;
 }

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/index.ts
@@ -9,7 +9,7 @@ import styles from './index.css';
 import type UiFormInputComponent from './input';
 import type UiFormTextareaComponent from './textarea';
 
-interface UiFormComponentSignature {
+interface UiFormSignature {
   Args: {
     data?: Record<string, any>;
     instructions?: string;
@@ -35,7 +35,7 @@ interface UiFormComponentSignature {
   };
 }
 
-export default class UiFormComponent extends Component<UiFormComponentSignature> {
+export default class UiFormComponent extends Component<UiFormSignature> {
   formId = guidFor(this);
   styles = styles;
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/information/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/information/index.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormInformationComponentSignature {
+interface UiFormInformationSignature {
   Args: {
     formId: string;
     instructions?: string;
@@ -10,7 +10,7 @@ interface UiFormInformationComponentSignature {
   };
 }
 
-export default class UiFormInformationComponent extends Component<UiFormInformationComponentSignature> {
+export default class UiFormInformationComponent extends Component<UiFormInformationSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/input/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/input/index.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormInputComponentSignature {
+interface UiFormInputSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -18,7 +18,7 @@ interface UiFormInputComponentSignature {
   };
 }
 
-export default class UiFormInputComponent extends Component<UiFormInputComponentSignature> {
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/textarea/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/form/textarea/index.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormTextareaComponentSignature {
+interface UiFormTextareaSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormTextareaComponentSignature {
   };
 }
 
-export default class UiFormTextareaComponent extends Component<UiFormTextareaComponentSignature> {
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/page/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/ui/page/index.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiPageComponentSignature {
+interface UiPageSignature {
   Args: {
     title: string;
   };
@@ -11,7 +11,7 @@ interface UiPageComponentSignature {
   };
 }
 
-export default class UiPageComponent extends Component<UiPageComponentSignature> {
+export default class UiPageComponent extends Component<UiPageSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-1/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-1/index.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget1ComponentSignature {}
+interface WidgetsWidget1Signature {}
 
-export default class WidgetsWidget1Component extends Component<WidgetsWidget1ComponentSignature> {
+export default class WidgetsWidget1Component extends Component<WidgetsWidget1Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-1/item/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-1/item/index.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget1ItemComponentSignature {
+interface WidgetsWidget1ItemSignature {
   Args: {
     title: string;
   };
 }
 
-export default class WidgetsWidget1ItemComponent extends Component<WidgetsWidget1ItemComponentSignature> {
+export default class WidgetsWidget1ItemComponent extends Component<WidgetsWidget1ItemSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-2/captions/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-2/captions/index.ts
@@ -5,13 +5,13 @@ import { tracked } from '@glimmer/tracking';
 import type { Summary } from '../../../../utils/components/widgets/widget-2';
 import styles from './index.css';
 
-interface WidgetsWidget2CaptionsComponentSignature {
+interface WidgetsWidget2CaptionsSignature {
   Args: {
     summaries?: Array<Summary>;
   };
 }
 
-export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsComponentSignature> {
+export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {
   styles = styles;
 
   @tracked currentIndex = 0;

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-2/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-2/index.ts
@@ -9,16 +9,16 @@ import {
 } from '../../../utils/components/widgets/widget-2';
 import styles from './index.css';
 
-interface WidgetsWidget2ComponentSignature {}
+interface WidgetsWidget2Signature {}
 
-export default class WidgetsWidget2Component extends Component<WidgetsWidget2ComponentSignature> {
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
   styles = styles;
 
   @tracked data = [] as Array<Data>;
   @tracked summaries = [] as Array<Summary>;
 
-  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget2ComponentSignature' */
-  constructor(owner: unknown, args: WidgetsWidget2ComponentSignature['Args']) {
+  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget2Signature' */
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-2/stacked-chart/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-2/stacked-chart/index.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Data } from '../../../../utils/components/widgets/widget-2';
 import styles from './index.css';
 
-interface WidgetsWidget2StackedChartComponentSignature {
+interface WidgetsWidget2StackedChartSignature {
   Args: {
     data: Array<Data>;
   };
 }
 
-export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartComponentSignature> {
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-3/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-3/index.ts
@@ -5,15 +5,15 @@ import type { Concert } from '../../../data/concert';
 import concertData from '../../../data/concert';
 import styles from './index.css';
 
-interface WidgetsWidget3ComponentSignature {}
+interface WidgetsWidget3Signature {}
 
-export default class WidgetsWidget3Component extends Component<WidgetsWidget3ComponentSignature> {
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
   styles = styles;
 
   @tracked concertData = {} as Concert;
 
-  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget3ComponentSignature' */
-  constructor(owner: unknown, args: WidgetsWidget3ComponentSignature['Args']) {
+  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget3Signature' */
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-3/tour-schedule/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-3/tour-schedule/index.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Concert } from '../../../../data/concert';
 import styles from './index.css';
 
-interface WidgetsWidget3TourScheduleComponentSignature {
+interface WidgetsWidget3TourScheduleSignature {
   Args: {
     concert: Concert;
   };
 }
 
-export default class WidgetsWidget3TourScheduleComponent extends Component<WidgetsWidget3TourScheduleComponentSignature> {
+export default class WidgetsWidget3TourScheduleComponent extends Component<WidgetsWidget3TourScheduleSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-3/tour-schedule/responsive-image/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-3/tour-schedule/responsive-image/index.ts
@@ -7,13 +7,13 @@ import type { Image } from '../../../../../data/concert';
 import { findBestFittingImage } from '../../../../../utils/components/widgets/widget-3';
 import styles from './index.css';
 
-interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
   Args: {
     images: Array<Image>;
   };
 }
 
-export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentSignature> {
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
   styles = styles;
 
   @tracked imageSource?: string;

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/index.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4ComponentSignature {}
+interface WidgetsWidget4Signature {}
 
-export default class WidgetsWidget4Component extends Component<WidgetsWidget4ComponentSignature> {
+export default class WidgetsWidget4Component extends Component<WidgetsWidget4Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/memo/actions/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/memo/actions/index.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4MemoActionsComponentSignature {
+interface WidgetsWidget4MemoActionsSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoActionsComponent extends Component<WidgetsWidget4MemoActionsComponentSignature> {
+export default class WidgetsWidget4MemoActionsComponent extends Component<WidgetsWidget4MemoActionsSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/memo/body/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/memo/body/index.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4MemoBodyComponentSignature {
+interface WidgetsWidget4MemoBodySignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoBodyComponent extends Component<WidgetsWidget4MemoBodyComponentSignature> {
+export default class WidgetsWidget4MemoBodyComponent extends Component<WidgetsWidget4MemoBodySignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/memo/header/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/memo/header/index.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4MemoHeaderComponentSignature {
+interface WidgetsWidget4MemoHeaderSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoHeaderComponent extends Component<WidgetsWidget4MemoHeaderComponentSignature> {
+export default class WidgetsWidget4MemoHeaderComponent extends Component<WidgetsWidget4MemoHeaderSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/memo/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-4/memo/index.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4MemoComponentSignature {}
+interface WidgetsWidget4MemoSignature {}
 
-export default class WidgetsWidget4MemoComponent extends Component<WidgetsWidget4MemoComponentSignature> {
+export default class WidgetsWidget4MemoComponent extends Component<WidgetsWidget4MemoSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-5/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/input/app/components/widgets/widget-5/index.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget5ComponentSignature {}
+interface WidgetsWidget5Signature {}
 
-export default class WidgetsWidget5Component extends Component<WidgetsWidget5ComponentSignature> {
+export default class WidgetsWidget5Component extends Component<WidgetsWidget5Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/navigation-menu/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/navigation-menu/index.ts
@@ -7,14 +7,14 @@ type MenuItem = {
   route: string;
 };
 
-interface NavigationMenuComponentSignature {
+interface NavigationMenuSignature {
   Args: {
     menuItems: Array<MenuItem>;
     name?: string;
   };
 }
 
-export default class NavigationMenuComponent extends Component<NavigationMenuComponentSignature> {
+export default class NavigationMenuComponent extends Component<NavigationMenuSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/products/product/card/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/products/product/card/index.ts
@@ -3,14 +3,14 @@ import Component from '@glimmer/component';
 import type { Product } from '../../../../data/products';
 import styles from './index.css';
 
-interface ProductsProductCardComponentSignature {
+interface ProductsProductCardSignature {
   Args: {
     product: Product;
     redirectTo?: string;
   };
 }
 
-export default class ProductsProductCardComponent extends Component<ProductsProductCardComponentSignature> {
+export default class ProductsProductCardComponent extends Component<ProductsProductCardSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/products/product/image/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/products/product/image/index.ts
@@ -3,13 +3,13 @@ import config from 'docs-app/config/environment';
 
 import styles from './index.css';
 
-interface ProductsProductImageComponentSignature {
+interface ProductsProductImageSignature {
   Args: {
     src: string;
   };
 }
 
-export default class ProductsProductImageComponent extends Component<ProductsProductImageComponentSignature> {
+export default class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
   styles = styles;
 
   get isTestEnvironment() {

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/tracks/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/tracks/index.ts
@@ -2,13 +2,13 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 import type { Track } from '../../data/album';
 
-interface TracksComponentSignature {
+interface TracksSignature {
   Args: {
     tracks?: Array<Track>;
   };
 }
 
-const TracksComponent = templateOnlyComponent<TracksComponentSignature>();
+const TracksComponent = templateOnlyComponent<TracksSignature>();
 
 export default TracksComponent;
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/tracks/list/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/tracks/list/index.ts
@@ -3,14 +3,14 @@ import Component from '@glimmer/component';
 import type { Track } from '../../../data/album';
 import styles from './index.css';
 
-interface TracksListComponentSignature {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Array<Track>;
   };
 }
 
-export default class TracksListComponent extends Component<TracksListComponentSignature> {
+export default class TracksListComponent extends Component<TracksListSignature> {
   styles = styles;
 
   get numColumns(): number {

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/tracks/table/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/tracks/table/index.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Track } from '../../../data/album';
 import styles from './index.css';
 
-interface TracksTableComponentSignature {
+interface TracksTableSignature {
   Args: {
     tracks?: Array<Track>;
   };
 }
 
-export default class TracksTableComponent extends Component<TracksTableComponentSignature> {
+export default class TracksTableComponent extends Component<TracksTableSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/checkbox/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/checkbox/index.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormCheckboxComponentSignature {
+interface UiFormCheckboxSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormCheckboxComponentSignature {
   };
 }
 
-export default class UiFormCheckboxComponent extends Component<UiFormCheckboxComponentSignature> {
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/field/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/field/index.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormFieldComponentSignature {
+interface UiFormFieldSignature {
   Args: {
     errorMessage?: string;
     isInline?: boolean;
@@ -23,7 +23,7 @@ interface UiFormFieldComponentSignature {
   };
 }
 
-export default class UiFormFieldComponent extends Component<UiFormFieldComponentSignature> {
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
   inputId = guidFor(this);
   styles = styles;
 }

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/index.ts
@@ -9,7 +9,7 @@ import styles from './index.css';
 import type UiFormInputComponent from './input';
 import type UiFormTextareaComponent from './textarea';
 
-interface UiFormComponentSignature {
+interface UiFormSignature {
   Args: {
     data?: Record<string, any>;
     instructions?: string;
@@ -35,7 +35,7 @@ interface UiFormComponentSignature {
   };
 }
 
-export default class UiFormComponent extends Component<UiFormComponentSignature> {
+export default class UiFormComponent extends Component<UiFormSignature> {
   formId = guidFor(this);
   styles = styles;
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/information/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/information/index.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormInformationComponentSignature {
+interface UiFormInformationSignature {
   Args: {
     formId: string;
     instructions?: string;
@@ -10,7 +10,7 @@ interface UiFormInformationComponentSignature {
   };
 }
 
-export default class UiFormInformationComponent extends Component<UiFormInformationComponentSignature> {
+export default class UiFormInformationComponent extends Component<UiFormInformationSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/input/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/input/index.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormInputComponentSignature {
+interface UiFormInputSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -18,7 +18,7 @@ interface UiFormInputComponentSignature {
   };
 }
 
-export default class UiFormInputComponent extends Component<UiFormInputComponentSignature> {
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/textarea/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/form/textarea/index.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiFormTextareaComponentSignature {
+interface UiFormTextareaSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -17,7 +17,7 @@ interface UiFormTextareaComponentSignature {
   };
 }
 
-export default class UiFormTextareaComponent extends Component<UiFormTextareaComponentSignature> {
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
   styles = styles;
 
   get errorMessage(): string | undefined {

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/page/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/ui/page/index.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface UiPageComponentSignature {
+interface UiPageSignature {
   Args: {
     title: string;
   };
@@ -11,7 +11,7 @@ interface UiPageComponentSignature {
   };
 }
 
-export default class UiPageComponent extends Component<UiPageComponentSignature> {
+export default class UiPageComponent extends Component<UiPageSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-1/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-1/index.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget1ComponentSignature {}
+interface WidgetsWidget1Signature {}
 
-export default class WidgetsWidget1Component extends Component<WidgetsWidget1ComponentSignature> {
+export default class WidgetsWidget1Component extends Component<WidgetsWidget1Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-1/item/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-1/item/index.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget1ItemComponentSignature {
+interface WidgetsWidget1ItemSignature {
   Args: {
     title: string;
   };
 }
 
-export default class WidgetsWidget1ItemComponent extends Component<WidgetsWidget1ItemComponentSignature> {
+export default class WidgetsWidget1ItemComponent extends Component<WidgetsWidget1ItemSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-2/captions/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-2/captions/index.ts
@@ -5,13 +5,13 @@ import { tracked } from '@glimmer/tracking';
 import type { Summary } from '../../../../utils/components/widgets/widget-2';
 import styles from './index.css';
 
-interface WidgetsWidget2CaptionsComponentSignature {
+interface WidgetsWidget2CaptionsSignature {
   Args: {
     summaries?: Array<Summary>;
   };
 }
 
-export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsComponentSignature> {
+export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {
   styles = styles;
 
   @tracked currentIndex = 0;

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-2/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-2/index.ts
@@ -9,16 +9,16 @@ import {
 } from '../../../utils/components/widgets/widget-2';
 import styles from './index.css';
 
-interface WidgetsWidget2ComponentSignature {}
+interface WidgetsWidget2Signature {}
 
-export default class WidgetsWidget2Component extends Component<WidgetsWidget2ComponentSignature> {
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
   styles = styles;
 
   @tracked data = [] as Array<Data>;
   @tracked summaries = [] as Array<Summary>;
 
-  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget2ComponentSignature' */
-  constructor(owner: unknown, args: WidgetsWidget2ComponentSignature['Args']) {
+  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget2Signature' */
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-2/stacked-chart/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-2/stacked-chart/index.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Data } from '../../../../utils/components/widgets/widget-2';
 import styles from './index.css';
 
-interface WidgetsWidget2StackedChartComponentSignature {
+interface WidgetsWidget2StackedChartSignature {
   Args: {
     data: Array<Data>;
   };
 }
 
-export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartComponentSignature> {
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-3/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-3/index.ts
@@ -5,15 +5,15 @@ import type { Concert } from '../../../data/concert';
 import concertData from '../../../data/concert';
 import styles from './index.css';
 
-interface WidgetsWidget3ComponentSignature {}
+interface WidgetsWidget3Signature {}
 
-export default class WidgetsWidget3Component extends Component<WidgetsWidget3ComponentSignature> {
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
   styles = styles;
 
   @tracked concertData = {} as Concert;
 
-  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget3ComponentSignature' */
-  constructor(owner: unknown, args: WidgetsWidget3ComponentSignature['Args']) {
+  /* @ts-expect-error Property 'Args' does not exist on type 'WidgetsWidget3Signature' */
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-3/tour-schedule/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-3/tour-schedule/index.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 import type { Concert } from '../../../../data/concert';
 import styles from './index.css';
 
-interface WidgetsWidget3TourScheduleComponentSignature {
+interface WidgetsWidget3TourScheduleSignature {
   Args: {
     concert: Concert;
   };
 }
 
-export default class WidgetsWidget3TourScheduleComponent extends Component<WidgetsWidget3TourScheduleComponentSignature> {
+export default class WidgetsWidget3TourScheduleComponent extends Component<WidgetsWidget3TourScheduleSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-3/tour-schedule/responsive-image/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-3/tour-schedule/responsive-image/index.ts
@@ -7,13 +7,13 @@ import type { Image } from '../../../../../data/concert';
 import { findBestFittingImage } from '../../../../../utils/components/widgets/widget-3';
 import styles from './index.css';
 
-interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
   Args: {
     images: Array<Image>;
   };
 }
 
-export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentSignature> {
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
   styles = styles;
 
   @tracked imageSource?: string;

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/index.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4ComponentSignature {}
+interface WidgetsWidget4Signature {}
 
-export default class WidgetsWidget4Component extends Component<WidgetsWidget4ComponentSignature> {
+export default class WidgetsWidget4Component extends Component<WidgetsWidget4Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/memo/actions/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/memo/actions/index.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4MemoActionsComponentSignature {
+interface WidgetsWidget4MemoActionsSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoActionsComponent extends Component<WidgetsWidget4MemoActionsComponentSignature> {
+export default class WidgetsWidget4MemoActionsComponent extends Component<WidgetsWidget4MemoActionsSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/memo/body/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/memo/body/index.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4MemoBodyComponentSignature {
+interface WidgetsWidget4MemoBodySignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoBodyComponent extends Component<WidgetsWidget4MemoBodyComponentSignature> {
+export default class WidgetsWidget4MemoBodyComponent extends Component<WidgetsWidget4MemoBodySignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/memo/header/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/memo/header/index.ts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4MemoHeaderComponentSignature {
+interface WidgetsWidget4MemoHeaderSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
-export default class WidgetsWidget4MemoHeaderComponent extends Component<WidgetsWidget4MemoHeaderComponentSignature> {
+export default class WidgetsWidget4MemoHeaderComponent extends Component<WidgetsWidget4MemoHeaderSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/memo/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-4/memo/index.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget4MemoComponentSignature {}
+interface WidgetsWidget4MemoSignature {}
 
-export default class WidgetsWidget4MemoComponent extends Component<WidgetsWidget4MemoComponentSignature> {
+export default class WidgetsWidget4MemoComponent extends Component<WidgetsWidget4MemoSignature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-5/index.ts
+++ b/type-css-modules/tests/fixtures/ember-app-nested/output/app/components/widgets/widget-5/index.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import styles from './index.css';
 
-interface WidgetsWidget5ComponentSignature {}
+interface WidgetsWidget5Signature {}
 
-export default class WidgetsWidget5Component extends Component<WidgetsWidget5ComponentSignature> {
+export default class WidgetsWidget5Component extends Component<WidgetsWidget5Signature> {
   styles = styles;
 }
 

--- a/type-css-modules/tests/utils/abstract-syntax-tree/css.test.js
+++ b/type-css-modules/tests/utils/abstract-syntax-tree/css.test.js
@@ -29,14 +29,14 @@ test('utils | abstract-syntax-tree | css > visit methods are undefined', functio
   assert.strictEqual(
     newFile,
     [
-      '.application{}',
-      '.header{}',
-      '.main{}',
-      '.footer{}',
-      '.copyright{}',
-      '.copyright .link{}',
+      '.application {}',
+      '.header {}',
+      '.main {}',
+      '.footer {}',
+      '.copyright {}',
+      '.copyright .link {}',
       '',
-    ].join('')
+    ].join('\n')
   );
 });
 
@@ -53,11 +53,36 @@ test('utils | abstract-syntax-tree | css > visit methods are well-defined', func
 
   const classNames = new Set();
 
-  AST.traverse(oldFile, {
-    ClassSelector(node) {
-      classNames.add(node.name);
+  const ast = AST.traverse(oldFile, {
+    Rule(node) {
+      const selectors = node.selector.split(/\s+/);
+
+      selectors.forEach((selector) => {
+        if (!selector.startsWith('.')) {
+          return;
+        }
+
+        const classSelector = selector.replace(/^\./, '');
+
+        classNames.add(classSelector);
+      });
     },
   });
+
+  const newFile = AST.print(ast);
+
+  assert.strictEqual(
+    newFile,
+    [
+      '.application {}',
+      '.header {}',
+      '.main {}',
+      '.footer {}',
+      '.copyright {}',
+      '.copyright .link {}',
+      '',
+    ].join('\n')
+  );
 
   assert.deepStrictEqual([...classNames].sort(), [
     'application',

--- a/type-css-modules/tests/utils/abstract-syntax-tree/css.test.js
+++ b/type-css-modules/tests/utils/abstract-syntax-tree/css.test.js
@@ -1,0 +1,70 @@
+import { ASTCSS as AST } from '../../../src/utils/abstract-syntax-tree.js';
+import { assert, test } from '../../helpers/testing.js';
+
+test('utils | abstract-syntax-tree | css > file is empty', function () {
+  const oldFile = '';
+
+  const ast = AST.traverse(oldFile);
+
+  const newFile = AST.print(ast);
+
+  assert.strictEqual(newFile, '');
+});
+
+test('utils | abstract-syntax-tree | css > visit methods are undefined', function () {
+  const oldFile = [
+    '.application {}',
+    '.header {}',
+    '.main {}',
+    '.footer {}',
+    '.copyright {}',
+    '.copyright .link {}',
+    '',
+  ].join('\n');
+
+  const ast = AST.traverse(oldFile);
+
+  const newFile = AST.print(ast);
+
+  assert.strictEqual(
+    newFile,
+    [
+      '.application{}',
+      '.header{}',
+      '.main{}',
+      '.footer{}',
+      '.copyright{}',
+      '.copyright .link{}',
+      '',
+    ].join('')
+  );
+});
+
+test('utils | abstract-syntax-tree | css > visit methods are well-defined', function () {
+  const oldFile = [
+    '.application {}',
+    '.header {}',
+    '.main {}',
+    '.footer {}',
+    '.copyright {}',
+    '.copyright .link {}',
+    '',
+  ].join('\n');
+
+  const classNames = new Set();
+
+  AST.traverse(oldFile, {
+    ClassSelector(node) {
+      classNames.add(node.name);
+    },
+  });
+
+  assert.deepStrictEqual([...classNames].sort(), [
+    'application',
+    'copyright',
+    'footer',
+    'header',
+    'link',
+    'main',
+  ]);
+});

--- a/type-css-modules/tests/utils/abstract-syntax-tree/css.test.js
+++ b/type-css-modules/tests/utils/abstract-syntax-tree/css.test.js
@@ -29,14 +29,14 @@ test('utils | abstract-syntax-tree | css > visit methods are undefined', functio
   assert.strictEqual(
     newFile,
     [
-      '.application {}',
-      '.header {}',
-      '.main {}',
-      '.footer {}',
-      '.copyright {}',
-      '.copyright .link {}',
+      '.application{}',
+      '.header{}',
+      '.main{}',
+      '.footer{}',
+      '.copyright{}',
+      '.copyright .link{}',
       '',
-    ].join('\n')
+    ].join('')
   );
 });
 
@@ -53,36 +53,11 @@ test('utils | abstract-syntax-tree | css > visit methods are well-defined', func
 
   const classNames = new Set();
 
-  const ast = AST.traverse(oldFile, {
-    Rule(node) {
-      const selectors = node.selector.split(/\s+/);
-
-      selectors.forEach((selector) => {
-        if (!selector.startsWith('.')) {
-          return;
-        }
-
-        const classSelector = selector.replace(/^\./, '');
-
-        classNames.add(classSelector);
-      });
+  AST.traverse(oldFile, {
+    ClassSelector(node) {
+      classNames.add(node.name);
     },
   });
-
-  const newFile = AST.print(ast);
-
-  assert.strictEqual(
-    newFile,
-    [
-      '.application {}',
-      '.header {}',
-      '.main {}',
-      '.footer {}',
-      '.copyright {}',
-      '.copyright .link {}',
-      '',
-    ].join('\n')
-  );
 
   assert.deepStrictEqual([...classNames].sort(), [
     'application',


### PR DESCRIPTION
## Description

`embroider-css-modules` assumes that there are packages that parse `*.css`, `*.hbs`, and `*.{js,ts}` files. Even so, we want to wrap around these packages and standardize the API, rather than directly consuming the packages in many files. (Note, within this project, the standardization is a variable called `AST`.) This will help us minimize impact if the packages are, e.g. no longer maintained, and need to be replaced.

In this pull request, I introduced the `AST` pattern from `ember-codemod-remove-css-modules` to `type-css-modules`. This helped me understand better what `css-tree` can (parsing) and can't do (preserving the format).

In commits 6-8, I renamed the component signatures to follow [the naming convention that `ember-source@4.12` introduced](https://github.com/emberjs/ember.js/pull/20356/files).