### PR TITLE
Improved formatting of CHANGELOGs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": "@changesets/changelog-git",
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "ijlee2/embroider-css-modules" }
+  ],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": [
-    "@changesets/changelog-github",
-    { "repo": "ijlee2/embroider-css-modules" }
-  ],
+  "changelog": "./format-changelogs.cjs",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/format-changelogs.cjs
+++ b/.changeset/format-changelogs.cjs
@@ -1,0 +1,52 @@
+async function getDependencyReleaseLine(
+  changesets,
+  dependenciesUpdated,
+  options,
+) {
+  const output = [
+    'getDependencyReleaseLine',
+    '',
+    'changesets:',
+    `${JSON.stringify(changesets)}`,
+    '',
+    'dependenciesUpdated:',
+    `${dependenciesUpdated}`,
+    '',
+    'options:',
+    `${options}`,
+    '',
+    '---',
+  ].join('\n');
+
+  return output;
+}
+
+async function getReleaseLine(changeset, type, options) {
+  const output = [
+    'getReleaseLine',
+    '',
+    'changeset.summary:',
+    `${changeset.summary}`,
+    '',
+    'changeset.releases:',
+    `${JSON.stringify(changeset.releases)}`,
+    '',
+    'changeset.commit:',
+    `${changeset.commit}`,
+    '',
+    'type:',
+    `${type}`,
+    '',
+    'options:',
+    `${options}`,
+    '',
+    '---',
+  ].join('\n');
+
+  return output;
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/.changeset/format-changelogs.cjs
+++ b/.changeset/format-changelogs.cjs
@@ -1,49 +1,124 @@
+const {
+  getInfo,
+  getInfoFromPullRequest,
+} = require('@changesets/get-github-info');
+
 async function getDependencyReleaseLine(
   changesets,
   dependenciesUpdated,
   options,
 ) {
-  const output = [
-    'getDependencyReleaseLine',
-    '',
-    'changesets:',
-    `${JSON.stringify(changesets)}`,
-    '',
-    'dependenciesUpdated:',
-    `${dependenciesUpdated}`,
-    '',
-    'options:',
-    `${options}`,
-    '',
-    '---',
-  ].join('\n');
+  if (dependenciesUpdated.length === 0) {
+    return '';
+  }
 
-  return output;
+  const changesetLink = `- Updated dependencies [${(
+    await Promise.all(
+      changesets.map(async (cs) => {
+        if (cs.commit) {
+          const { links } = await getInfo({
+            repo: 'ijlee2/embroider-css-modules',
+            commit: cs.commit,
+          });
+
+          return links.commit;
+        }
+      }),
+    )
+  )
+    .filter((_) => _)
+    .join(', ')}]:`;
+
+  const updatedDepenenciesList = dependenciesUpdated.map((dependency) => {
+    return `  - ${dependency.name}@${dependency.newVersion}`;
+  });
+
+  return [changesetLink, ...updatedDepenenciesList].join('\n');
 }
 
 async function getReleaseLine(changeset, type, options) {
-  const output = [
-    'getReleaseLine',
-    '',
-    'changeset.summary:',
-    `${changeset.summary}`,
-    '',
-    'changeset.releases:',
-    `${JSON.stringify(changeset.releases)}`,
-    '',
-    'changeset.commit:',
-    `${changeset.commit}`,
-    '',
-    'type:',
-    `${type}`,
-    '',
-    'options:',
-    `${options}`,
-    '',
-    '---',
-  ].join('\n');
+  let prFromSummary;
+  let commitFromSummary;
+  let usersFromSummary = [];
 
-  return output;
+  const replacedChangelog = changeset.summary
+    .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+      let num = Number(pr);
+
+      if (!isNaN(num)) {
+        prFromSummary = num;
+      }
+
+      return '';
+    })
+    .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+      commitFromSummary = commit;
+
+      return '';
+    })
+    .replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
+      usersFromSummary.push(user);
+
+      return '';
+    })
+    .trim();
+
+  const [firstLine, ...futureLines] = replacedChangelog
+    .split('\n')
+    .map((l) => l.trimRight());
+
+  const links = await (async () => {
+    if (prFromSummary !== undefined) {
+      let { links } = await getInfoFromPullRequest({
+        repo: 'ijlee2/embroider-css-modules',
+        pull: prFromSummary,
+      });
+
+      if (commitFromSummary) {
+        links = {
+          ...links,
+          commit: `[\`${commitFromSummary}\`](https://github.com/ijlee2/embroider-css-modules/commit/${commitFromSummary})`,
+        };
+      }
+
+      return links;
+    }
+
+    const commitToFetchFrom = commitFromSummary || changeset.commit;
+
+    if (commitToFetchFrom) {
+      const { links } = await getInfo({
+        repo: 'ijlee2/embroider-css-modules',
+        commit: commitToFetchFrom,
+      });
+
+      return links;
+    }
+
+    return {
+      commit: null,
+      pull: null,
+      user: null,
+    };
+  })();
+
+  const users = usersFromSummary.length
+    ? usersFromSummary
+        .map((userFromSummary) => {
+          return `[@${userFromSummary}](https://github.com/${userFromSummary})`;
+        })
+        .join(', ')
+    : links.user;
+
+  const prefix = [
+    links.pull === null ? '' : ` ${links.pull}`,
+    links.commit === null ? '' : ` ${links.commit}`,
+    users === null ? '' : ` Thanks ${users}!`,
+  ].join('');
+
+  return `\n\n-${prefix ? `${prefix} -` : ''} ${firstLine}\n${futureLines
+    .map((l) => `  ${l}`)
+    .join('\n')}`;
 }
 
 module.exports = {

--- a/.changeset/format-changelogs.cjs
+++ b/.changeset/format-changelogs.cjs
@@ -19,37 +19,22 @@ async function extractInformation(changeset) {
   };
 }
 
-async function getDependencyReleaseLine(
-  changesets,
-  dependenciesUpdated,
-  options,
-) {
+async function getDependencyReleaseLine(changesets, dependenciesUpdated) {
   if (dependenciesUpdated.length === 0) {
     return '';
   }
 
-  const changesetLink = `- Updated dependencies [${(
-    await Promise.all(
-      changesets.map(async (cs) => {
-        if (cs.commit) {
-          const { links } = await getInfo({
-            repo: 'ijlee2/embroider-css-modules',
-            commit: cs.commit,
-          });
-
-          return links.commit;
-        }
-      }),
-    )
-  )
-    .filter((_) => _)
-    .join(', ')}]:`;
-
-  const updatedDepenenciesList = dependenciesUpdated.map((dependency) => {
-    return `  - ${dependency.name}@${dependency.newVersion}`;
+  const commits = changesets.map((changeset) => {
+    return `[${changeset.commit}](https://github.com/${repo}/commit/${changeset.commit})`;
   });
 
-  return [changesetLink, ...updatedDepenenciesList].join('\n');
+  let line = `- Updated dependencies (${commits.join(', ')})`;
+
+  dependenciesUpdated.forEach((dependency) => {
+    line += `  - ${dependency.name}@${dependency.newVersion}`;
+  });
+
+  return line;
 }
 
 async function getReleaseLine(changeset) {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "test": "pnpm --filter '*' test"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.1",
+    "@changesets/get-github-info": "^0.5.2",
     "concurrently": "^8.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "pnpm --filter '*' test"
   },
   "devDependencies": {
-    "@changesets/changelog-git": "^0.1.14",
+    "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.1",
     "concurrently": "^8.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,12 @@ importers:
 
   .:
     devDependencies:
-      '@changesets/changelog-github':
-        specifier: ^0.4.8
-        version: 0.4.8
       '@changesets/cli':
         specifier: ^2.26.1
         version: 2.26.1
+      '@changesets/get-github-info':
+        specifier: ^0.5.2
+        version: 0.5.2
       concurrently:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1908,16 +1908,6 @@ packages:
     resolution: {integrity: sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==}
     dependencies:
       '@changesets/types': 5.2.1
-    dev: true
-
-  /@changesets/changelog-github@0.4.8:
-    resolution: {integrity: sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==}
-    dependencies:
-      '@changesets/get-github-info': 0.5.2
-      '@changesets/types': 5.2.1
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
     dev: true
 
   /@changesets/cli@2.26.1:
@@ -6959,11 +6949,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-obj: 2.0.0
-    dev: true
-
-  /dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
     dev: true
 
   /duplexer2@0.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,9 @@ importers:
 
   .:
     devDependencies:
-      '@changesets/changelog-git':
-        specifier: ^0.1.14
-        version: 0.1.14
+      '@changesets/changelog-github':
+        specifier: ^0.4.8
+        version: 0.4.8
       '@changesets/cli':
         specifier: ^2.26.1
         version: 2.26.1
@@ -1910,6 +1910,16 @@ packages:
       '@changesets/types': 5.2.1
     dev: true
 
+  /@changesets/changelog-github@0.4.8:
+    resolution: {integrity: sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==}
+    dependencies:
+      '@changesets/get-github-info': 0.5.2
+      '@changesets/types': 5.2.1
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
   /@changesets/cli@2.26.1:
     resolution: {integrity: sha512-XnTa+b51vt057fyAudvDKGB0Sh72xutQZNAdXkCqPBKO2zvs2yYZx5hFZj1u9cbtpwM6Sxtcr02/FQJfZOzemQ==}
     hasBin: true
@@ -1975,6 +1985,15 @@ packages:
       chalk: 2.4.2
       fs-extra: 7.0.1
       semver: 5.7.1
+    dev: true
+
+  /@changesets/get-github-info@0.5.2:
+    resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.6.9
+    transitivePeerDependencies:
+      - encoding
     dev: true
 
   /@changesets/get-release-plan@3.0.16:
@@ -6635,6 +6654,10 @@ packages:
       whatwg-url: 8.7.0
     dev: true
 
+  /dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+    dev: true
+
   /date-fns@2.29.3:
     resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
     engines: {node: '>=0.11'}
@@ -6936,6 +6959,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-obj: 2.0.0
+    dev: true
+
+  /dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
     dev: true
 
   /duplexer2@0.0.2:


### PR DESCRIPTION
## Background

The built-in implementations (`@changesets/changelog-git` and `@changesets/changelog-github`) currently pose a large technical risk (the code is overly complex and in need of refactoring) and generate `CHANGELOG`'s that I don't find useful (compared to the output from [`lerna-changelog`](https://github.com/lerna/lerna-changelog)).


<details>

<summary>With <code>@changesets/changelog-git</code></summary>

```md
## 0.1.1

### Patch Changes

- 6d905b59: Updated development dependencies (formatting changed due to trailing commas)
- 1e681b4c: Added CONTRIBUTING.md
```
</details>


<details>

<summary>With <code>@changesets/changelog-github</code></summary>

```md
## 0.1.1

### Patch Changes

- [#25](https://github.com/ijlee2/embroider-css-modules/pull/25) [`6d905b59`](https://github.com/ijlee2/embroider-css-modules/commit/6d905b599de977a8f4a59cee4bf99c9129ad8462) Thanks [@ijlee2](https://github.com/ijlee2)! - Updated development dependencies (formatting changed due to trailing commas)

- [#24](https://github.com/ijlee2/embroider-css-modules/pull/24) [`1e681b4c`](https://github.com/ijlee2/embroider-css-modules/commit/1e681b4c1baf817110de35fc6df85cc74c557b7e) Thanks [@ijlee2](https://github.com/ijlee2)! - Added CONTRIBUTING.md
```
</details>


By writing a customer formatter, we can create `CHANGELOG`'s that help maintainers and end-developers more. The output is inspired from `lerna-changelog` and will look like:

```md
## 0.1.1

### Patch Changes

- [#25](https://github.com/ijlee2/embroider-css-modules/pull/25) Updated development dependencies (formatting changed due to trailing commas) ([@ijlee2](https://github.com/ijlee2))
- [#24](https://github.com/ijlee2/embroider-css-modules/pull/24) Added CONTRIBUTING.md ([@ijlee2](https://github.com/ijlee2))
```


## References

- [Modifying changelog format](https://github.com/changesets/changesets/blob/main/docs/modifying-changelog-format.md)
- [Formatter implementation from `@changesets/changelog-git`](https://github.com/changesets/changesets/blob/%40changesets/changelog-git%400.1.14/packages/changelog-git/src/index.ts)
- [Formatter implementation from `@changesets/changelog-github`](https://github.com/changesets/changesets/blob/%40changesets/changelog-github%400.4.8/packages/changelog-github/src/index.ts)