### PR TITLE
Installed @embroider/addon-shim@1.8.5-unstable.f004d11 to allow nesting v2 addons

### DIFF
--- a/.changeset/lazy-balloons-eat.md
+++ b/.changeset/lazy-balloons-eat.md
@@ -1,0 +1,7 @@
+---
+"embroider-css-modules-temporary": patch
+"embroider-css-modules": patch
+"sample-v2-addon": patch
+---
+
+Installed @embroider/addon-shim@1.8.5-unstable.f004d11 to allow nesting v2 addons

--- a/docs/sample-v2-addon/package.json
+++ b/docs/sample-v2-addon/package.json
@@ -58,7 +58,7 @@
     "test": "echo 'A v2 addon does not have tests, run tests in tests/sample-v2-addon'"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.4",
+    "@embroider/addon-shim": "1.8.5-unstable.f004d11",
     "embroider-css-modules": "workspace:*"
   },
   "devDependencies": {

--- a/packages/embroider-css-modules-temporary/package.json
+++ b/packages/embroider-css-modules-temporary/package.json
@@ -54,7 +54,7 @@
     "test": "echo 'A v2 addon does not have tests, run tests in tests/embroider-css-modules-temporary'"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.4",
+    "@embroider/addon-shim": "1.8.5-unstable.f004d11",
     "embroider-css-modules": "workspace:*"
   },
   "devDependencies": {

--- a/packages/embroider-css-modules/package.json
+++ b/packages/embroider-css-modules/package.json
@@ -54,7 +54,7 @@
     "test": "echo 'A v2 addon does not have tests, run tests in tests/embroider-css-modules'"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.4"
+    "@embroider/addon-shim": "1.8.5-unstable.f004d11"
   },
   "devDependencies": {
     "@babel/core": "^7.21.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,8 +410,8 @@ importers:
   docs/sample-v2-addon:
     dependencies:
       '@embroider/addon-shim':
-        specifier: ^1.8.4
-        version: 1.8.4
+        specifier: 1.8.5-unstable.f004d11
+        version: 1.8.5-unstable.f004d11
       embroider-css-modules:
         specifier: workspace:*
         version: link:../../packages/embroider-css-modules
@@ -583,8 +583,8 @@ importers:
   packages/embroider-css-modules:
     dependencies:
       '@embroider/addon-shim':
-        specifier: ^1.8.4
-        version: 1.8.4
+        specifier: 1.8.5-unstable.f004d11
+        version: 1.8.5-unstable.f004d11
     devDependencies:
       '@babel/core':
         specifier: ^7.21.5
@@ -674,8 +674,8 @@ importers:
   packages/embroider-css-modules-temporary:
     dependencies:
       '@embroider/addon-shim':
-        specifier: ^1.8.4
-        version: 1.8.4
+        specifier: 1.8.5-unstable.f004d11
+        version: 1.8.5-unstable.f004d11
       embroider-css-modules:
         specifier: workspace:*
         version: link:../embroider-css-modules
@@ -2799,6 +2799,18 @@ packages:
       semver: 7.5.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@embroider/addon-shim@1.8.5-unstable.f004d11:
+    resolution: {integrity: sha512-/50gg4V6KhwP3iq3HKNpfcOOr7Ke7Jdi8LKIPBXSDRYkfLaR1ciOGwfUjyaXUCzD/a6PcX/ccFsoH4N2/710Yw==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@embroider/shared-internals': 2.0.1-unstable.f004d11
+      broccoli-funnel: 3.0.8
+      semver: 7.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@embroider/babel-loader-8@2.0.0(@embroider/core@2.1.1)(supports-color@8.1.1)(webpack@5.81.0):
     resolution: {integrity: sha512-a1bLodfox8JEgNHuhiIBIcXJ4b8NNnKWYkMIpJx216pn80Jf1jcFosQpxnqC8hYHrnG0XRKzQ9zJYgJXoa1wfg==}
@@ -2962,6 +2974,21 @@ packages:
       resolve-package-path: 4.0.3
       semver: 7.5.0
       typescript-memoize: 1.1.1
+    dev: true
+
+  /@embroider/shared-internals@2.0.1-unstable.f004d11:
+    resolution: {integrity: sha512-lEgMNkHSodDQTczhpqIcT1f/LBZmHK6VTcMuLZWUBYXa9C5VEWAlj+zxrdblwbPRKzD3kExCh+xEoZ/vDhWLvQ==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      babel-import-util: 1.3.0
+      ember-rfc176-data: 0.3.18
+      fs-extra: 9.1.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      resolve-package-path: 4.0.3
+      semver: 7.5.0
+      typescript-memoize: 1.1.1
+    dev: false
 
   /@embroider/test-setup@2.1.1:
     resolution: {integrity: sha512-t81a2z2OEFAOZVbV7wkgiDuCyZ3ajD7J7J+keaTfNSRiXoQgeFFASEECYq1TCsH8m/R+xHMRiY59apF2FIeFhw==}


### PR DESCRIPTION
## Description

When a v2 addon depends on `embroider-css-modules-temporary@0.1.2` (also a v2 addon), running the consuming app (or building its test app) results in an error:

```sh
Cannot read properties of undefined (reading 'registerV2Addon')
```

Related: https://github.com/embroider-build/embroider/issues/1325