### PR TITLE
Removed dependency on embroider-css-modules

### DIFF
--- a/.changeset/short-impalas-cheer.md
+++ b/.changeset/short-impalas-cheer.md
@@ -1,0 +1,5 @@
+---
+"embroider-css-modules-temporary": patch
+---
+
+Removed dependency on embroider-css-modules

--- a/packages/embroider-css-modules-temporary/package.json
+++ b/packages/embroider-css-modules-temporary/package.json
@@ -54,8 +54,7 @@
     "test": "echo 'A v2 addon does not have tests, run tests in tests/embroider-css-modules-temporary'"
   },
   "dependencies": {
-    "@embroider/addon-shim": "1.8.5-unstable.f004d11",
-    "embroider-css-modules": "workspace:*"
+    "@embroider/addon-shim": "1.8.5-unstable.f004d11"
   },
   "devDependencies": {
     "@babel/core": "^7.21.5",

--- a/packages/embroider-css-modules-temporary/src/helpers/local-class-new.ts
+++ b/packages/embroider-css-modules-temporary/src/helpers/local-class-new.ts
@@ -1,3 +1,53 @@
-import LocalClassNewHelper from 'embroider-css-modules/helpers/local-class';
+import Helper from '@ember/component/helper';
+import { assert } from '@ember/debug';
 
-export default LocalClassNewHelper;
+type IndexSignatureParameter = string | number | symbol;
+
+type LocalClassName<T extends IndexSignatureParameter> = T;
+
+type Styles<T extends IndexSignatureParameter> = Record<
+  LocalClassName<T>,
+  string
+>;
+
+type MaybeLocalClassName<T extends IndexSignatureParameter> =
+  | LocalClassName<T>[]
+  | LocalClassName<T>
+  | undefined
+  | null;
+
+interface LocalClassNewHelperSignature<T extends IndexSignatureParameter> {
+  Args: {
+    Positional: [Styles<T>, ...MaybeLocalClassName<T>[]];
+  };
+  Return: string;
+}
+
+export default class LocalClassNewHelper<
+  T extends IndexSignatureParameter,
+> extends Helper<LocalClassNewHelperSignature<T>> {
+  compute(positional: LocalClassNewHelperSignature<T>['Args']['Positional']) {
+    const [styles, ...localClassNames] = positional;
+
+    assert('The styles object is undefined.', styles);
+
+    const classNames = localClassNames.reduce<string[]>(
+      (accumulator, localClassName) => {
+        if (localClassName === undefined || localClassName === null) {
+          return accumulator;
+        }
+
+        if (Array.isArray(localClassName)) {
+          accumulator.push(...localClassName.map((element) => styles[element]));
+        } else {
+          accumulator.push(styles[localClassName]);
+        }
+
+        return accumulator;
+      },
+      [],
+    );
+
+    return classNames.filter(Boolean).join(' ');
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,9 +676,6 @@ importers:
       '@embroider/addon-shim':
         specifier: 1.8.5-unstable.f004d11
         version: 1.8.5-unstable.f004d11
-      embroider-css-modules:
-        specifier: workspace:*
-        version: link:../embroider-css-modules
     devDependencies:
       '@babel/core':
         specifier: ^7.21.5


### PR DESCRIPTION
## Background

I found a failing case for `embroider-css-modules-temporary@0.1.3`, where the styles for `my-v1-addon` wouldn't take place. The addon depends on `ember-css-modules` and `embroider-css-modules-temporary` as follows:

```
my-v1-addon
├── ember-css-modules
└── my-v2-addon
    └── embroider-css-modules-temporary
```

I suspect that `embroider-css-modules-temporary@0.1.3` pulled in `embroider-css-modules@0.1.3`, whose `{{local-class}}` helper took priority over the one from `ember-css-modules`.

So when it's time for `ember-css-modules` to compile the template and convert the `local-class` attributes to `{{local-class}}` helpers, the helper from `embroider-css-modules` is referenced instead.


## Solution

I duplicated the helper so that `embroider-css-modules-temporary` does not depend on `embroider-css-modules`.


### Testing locally

I built `embroider-css-modules-temporary` to get the updated `dist` folder. I copy-pasted the files in `dist` to the monorepo's `node_modules/embroider-css-modules-temporary` and checked if the styles for `my-v1-addon` take place.
