### PR TITLE
Replace assert.deepEqual with assert.deepStrictEqual

### DIFF
--- a/.changeset/weak-ways-sleep.md
+++ b/.changeset/weak-ways-sleep.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-remove-ember-css-modules": patch
+---
+
+Replace assert.deepEqual with assert.deepStrictEqual

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/analyze-app/glint.test.js
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/analyze-app/glint.test.js
@@ -11,5 +11,5 @@ import {
 test('migration | ember-app | steps | analyze-app > glint', function () {
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeApp(options), context);
+  assert.deepStrictEqual(analyzeApp(options), context);
 });

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/analyze-app/javascript.test.js
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/analyze-app/javascript.test.js
@@ -11,5 +11,5 @@ import {
 test('migration | ember-app | steps | analyze-app > javascript', function () {
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeApp(options), context);
+  assert.deepStrictEqual(analyzeApp(options), context);
 });

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/analyze-app/nested.test.js
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/analyze-app/nested.test.js
@@ -11,5 +11,5 @@ import {
 test('migration | ember-app | steps | analyze-app > nested', function () {
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeApp(options), context);
+  assert.deepStrictEqual(analyzeApp(options), context);
 });

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/analyze-app/typescript.test.js
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/analyze-app/typescript.test.js
@@ -11,5 +11,5 @@ import {
 test('migration | ember-app | steps | analyze-app > typescript', function () {
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeApp(options), context);
+  assert.deepStrictEqual(analyzeApp(options), context);
 });

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/glint.test.js
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/glint.test.js
@@ -22,7 +22,7 @@ test('migration | ember-app | steps | create-options > glint', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     __styles__: 'styles',
     componentStructure: 'flat',
     project: {

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/idempotency.test.js
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/idempotency.test.js
@@ -21,7 +21,7 @@ test('migration | ember-app | steps | create-options > idempotency', function ()
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     __styles__: 'styles',
     componentStructure: 'flat',
     project: {

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/javascript.test.js
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/javascript.test.js
@@ -20,7 +20,7 @@ test('migration | ember-app | steps | create-options > javascript', function () 
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     __styles__: 'styles',
     componentStructure: 'flat',
     project: {

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/nested.test.js
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/nested.test.js
@@ -22,7 +22,7 @@ test('migration | ember-app | steps | create-options > nested', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     __styles__: 'styles',
     componentStructure: 'nested',
     project: {

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/typescript.test.js
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/create-options/typescript.test.js
@@ -21,7 +21,7 @@ test('migration | ember-app | steps | create-options > typescript', function () 
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     __styles__: 'styles',
     componentStructure: 'flat',
     project: {


### PR DESCRIPTION
## Description

While [documenting `@codemod-utils/tests`](https://github.com/ijlee2/codemod-utils/pull/11), I learned that `assert.deepEqual` is an alias of `assert.deepStrictEqual` and the latter should be used to avoid unexpected results.

> **Strict assertion mode**
>
> An alias of [assert.deepStrictEqual()](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message).
>
> **Legacy assertion mode**
> 
> [Stability: 3](https://nodejs.org/api/documentation.html#stability-index) - Legacy: Use [assert.deepStrictEqual()](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message) instead.
>
> Tests for deep equality between the actual and expected parameters. Consider using [assert.deepStrictEqual()](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message) instead. [assert.deepEqual()](https://nodejs.org/api/assert.html#assertdeepequalactual-expected-message) can have surprising results.

https://nodejs.org/api/assert.html#assertdeepequalactual-expected-message