### PR TITLE
Patched 0.2.0-alpha.1

### DIFF
--- a/.changeset/selfish-years-turn.md
+++ b/.changeset/selfish-years-turn.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-remove-ember-css-modules": patch
+---
+
+Updated latestVersions

--- a/packages/ember-codemod-remove-ember-css-modules/src/utils/blueprints/get-version.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/src/utils/blueprints/get-version.ts
@@ -3,8 +3,8 @@ import { decideVersion } from '@codemod-utils/blueprints';
 import type { Options } from '../../types/index.js';
 
 const latestVersions = new Map([
-  ['embroider-css-modules', '0.1.6'],
-  ['type-css-modules', '0.1.4'],
+  ['embroider-css-modules', '0.1.7'],
+  ['type-css-modules', '0.1.5'],
   ['webpack', '5.86.0'],
 ]);
 

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/package.json
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/package.json
@@ -91,7 +91,7 @@
     "ember-template-lint-plugin-prettier": "^4.1.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "embroider-css-modules": "^0.1.6",
+    "embroider-css-modules": "^0.1.7",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.4.9",
@@ -108,7 +108,7 @@
     "stylelint-config-standard": "^32.0.0",
     "stylelint-no-unsupported-browser-features": "^6.1.0",
     "stylelint-order": "^6.0.3",
-    "type-css-modules": "^0.1.4",
+    "type-css-modules": "^0.1.5",
     "typescript": "^5.0.3",
     "webpack": "^5.77.0"
   },

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/package.json
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/package.json
@@ -83,7 +83,7 @@
     "ember-template-lint-plugin-prettier": "^4.1.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "embroider-css-modules": "^0.1.6",
+    "embroider-css-modules": "^0.1.7",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.4.9",

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/package.json
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/package.json
@@ -91,7 +91,7 @@
     "ember-template-lint-plugin-prettier": "^4.1.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "embroider-css-modules": "^0.1.6",
+    "embroider-css-modules": "^0.1.7",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.4.9",
@@ -108,7 +108,7 @@
     "stylelint-config-standard": "^32.0.0",
     "stylelint-no-unsupported-browser-features": "^6.1.0",
     "stylelint-order": "^6.0.3",
-    "type-css-modules": "^0.1.4",
+    "type-css-modules": "^0.1.5",
     "typescript": "^5.0.3",
     "webpack": "^5.77.0"
   },

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/package.json
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/package.json
@@ -87,7 +87,7 @@
     "ember-template-lint-plugin-prettier": "^4.1.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "embroider-css-modules": "^0.1.6",
+    "embroider-css-modules": "^0.1.7",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.4.9",
@@ -104,7 +104,7 @@
     "stylelint-config-standard": "^32.0.0",
     "stylelint-no-unsupported-browser-features": "^6.1.0",
     "stylelint-order": "^6.0.3",
-    "type-css-modules": "^0.1.4",
+    "type-css-modules": "^0.1.5",
     "typescript": "^5.0.3",
     "webpack": "^5.77.0"
   },

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-package-json/glint/output/package.json
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-package-json/glint/output/package.json
@@ -91,7 +91,7 @@
     "ember-template-lint-plugin-prettier": "^4.1.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "embroider-css-modules": "^0.1.6",
+    "embroider-css-modules": "^0.1.7",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.4.9",
@@ -108,7 +108,7 @@
     "stylelint-config-standard": "^32.0.0",
     "stylelint-no-unsupported-browser-features": "^6.1.0",
     "stylelint-order": "^6.0.3",
-    "type-css-modules": "^0.1.4",
+    "type-css-modules": "^0.1.5",
     "typescript": "^5.0.3",
     "webpack": "^5.77.0"
   },

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-package-json/javascript/output/package.json
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-package-json/javascript/output/package.json
@@ -83,7 +83,7 @@
     "ember-template-lint-plugin-prettier": "^4.1.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "embroider-css-modules": "^0.1.6",
+    "embroider-css-modules": "^0.1.7",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.4.9",

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-package-json/nested/output/package.json
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-package-json/nested/output/package.json
@@ -91,7 +91,7 @@
     "ember-template-lint-plugin-prettier": "^4.1.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "embroider-css-modules": "^0.1.6",
+    "embroider-css-modules": "^0.1.7",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.4.9",
@@ -108,7 +108,7 @@
     "stylelint-config-standard": "^32.0.0",
     "stylelint-no-unsupported-browser-features": "^6.1.0",
     "stylelint-order": "^6.0.3",
-    "type-css-modules": "^0.1.4",
+    "type-css-modules": "^0.1.5",
     "typescript": "^5.0.3",
     "webpack": "^5.77.0"
   },

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-package-json/typescript/output/package.json
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-package-json/typescript/output/package.json
@@ -87,7 +87,7 @@
     "ember-template-lint-plugin-prettier": "^4.1.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "embroider-css-modules": "^0.1.6",
+    "embroider-css-modules": "^0.1.7",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.4.9",
@@ -104,7 +104,7 @@
     "stylelint-config-standard": "^32.0.0",
     "stylelint-no-unsupported-browser-features": "^6.1.0",
     "stylelint-order": "^6.0.3",
-    "type-css-modules": "^0.1.4",
+    "type-css-modules": "^0.1.5",
     "typescript": "^5.0.3",
     "webpack": "^5.77.0"
   },


### PR DESCRIPTION
## Description

I was able to run `npx ember-codemod-remove-ember-css-modules@0.2.0-alpha.1` on [`ember-container-query/docs-app`](https://github.com/ijlee2/ember-container-query/tree/93995d53a41e322969be1980b871f986ac21b42f/docs-app). Before making a stable release, I'll go ahead with updating `latestVersions`.

<img width="900" alt="" src="https://github.com/ijlee2/embroider-css-modules/assets/16869656/aab60594-002a-4c52-a534-0bfb1527a005">

<img width="900" alt="" src="https://github.com/ijlee2/embroider-css-modules/assets/16869656/7c0d1cba-f920-4786-b7ad-06de0bf8e039">

<img width="600" alt="" src="https://github.com/ijlee2/embroider-css-modules/assets/16869656/ba2c89c6-5274-4dd7-8ca7-d54dc9ff546c">
