### PR TITLE
Optimized output code (removed unnecessary {{local-class}} helper)

### DIFF
--- a/.changeset/chatty-suns-trade.md
+++ b/.changeset/chatty-suns-trade.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-remove-ember-css-modules": minor
+---
+
+Optimized output code (removed unnecessary {{local-class}} helper)

--- a/packages/ember-codemod-remove-ember-css-modules/src/migration/ember-app/steps/shared/update-templates.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/src/migration/ember-app/steps/shared/update-templates.ts
@@ -433,10 +433,23 @@ function removeLocalClassAttributes(file: string, data: Data): string {
       }
 
       node.key = 'class';
+
+      const newValue = transformParam(node.value);
+
+      // @ts-ignore: Assume that types from external packages are correct
+      if (newValue.type === 'StringLiteral') {
+        node.value = AST.builders.path(
+          // @ts-ignore: Assume that types from external packages are correct
+          `this.${data.__styles__}.${newValue.value}`,
+        );
+
+        return;
+      }
+
       node.value = AST.builders.sexpr('local-class', [
         AST.builders.path(`this.${data.__styles__}`),
         // @ts-ignore: Assume that types from external packages are correct
-        transformParam(node.value),
+        newValue,
       ]);
     },
   });

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/app/components/tracks/list.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/app/components/tracks/list.hbs
@@ -25,7 +25,7 @@
           {{svg-jar
             "alpha-e-box"
             aria-hidden="true"
-            class=(local-class this.styles "icon-explicit")
+            class=this.styles.icon-explicit
           }}
         </span>
       {{/if}}

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/app/components/ui/form/checkbox.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/app/components/ui/form/checkbox.hbs
@@ -41,7 +41,7 @@
         {{svg-jar
           "check"
           aria-hidden="true"
-          class=(local-class this.styles "checkmark-icon")
+          class=this.styles.checkmark-icon
         }}
       {{/if}}
     </span>

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/app/components/widgets/widget-2/captions.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/app/components/widgets/widget-2/captions.hbs
@@ -71,7 +71,7 @@
             {{svg-jar
               "chevron-left"
               aria-hidden="true"
-              class=(local-class this.styles "icon")
+              class=this.styles.icon
             }}
 
           {{/if}}
@@ -93,7 +93,7 @@
             {{svg-jar
               "chevron-right"
               aria-hidden="true"
-              class=(local-class this.styles "icon")
+              class=this.styles.icon
             }}
 
           {{/if}}

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/app/components/widgets/widget-4/memo/actions.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-glint/output/app/components/widgets/widget-4/memo/actions.hbs
@@ -30,7 +30,7 @@
     {{svg-jar
       "heart-outline"
       aria-hidden="true"
-      class=(local-class this.styles "icon")
+      class=this.styles.icon
     }}
   </button>
 
@@ -38,7 +38,7 @@
     {{svg-jar
       "share-variant-outline"
       aria-hidden="true"
-      class=(local-class this.styles "icon")
+      class=this.styles.icon
     }}
   </button>
 </div>

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/app/components/tracks/list.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/app/components/tracks/list.hbs
@@ -25,7 +25,7 @@
           {{svg-jar
             "alpha-e-box"
             aria-hidden="true"
-            class=(local-class this.styles "icon-explicit")
+            class=this.styles.icon-explicit
           }}
         </span>
       {{/if}}

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/app/components/ui/form/checkbox.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/app/components/ui/form/checkbox.hbs
@@ -41,7 +41,7 @@
         {{svg-jar
           "check"
           aria-hidden="true"
-          class=(local-class this.styles "checkmark-icon")
+          class=this.styles.checkmark-icon
         }}
       {{/if}}
     </span>

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/app/components/widgets/widget-2/captions.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/app/components/widgets/widget-2/captions.hbs
@@ -71,7 +71,7 @@
             {{svg-jar
               "chevron-left"
               aria-hidden="true"
-              class=(local-class this.styles "icon")
+              class=this.styles.icon
             }}
 
           {{/if}}
@@ -93,7 +93,7 @@
             {{svg-jar
               "chevron-right"
               aria-hidden="true"
-              class=(local-class this.styles "icon")
+              class=this.styles.icon
             }}
 
           {{/if}}

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/app/components/widgets/widget-4/memo/actions.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-javascript/output/app/components/widgets/widget-4/memo/actions.hbs
@@ -30,7 +30,7 @@
     {{svg-jar
       "heart-outline"
       aria-hidden="true"
-      class=(local-class this.styles "icon")
+      class=this.styles.icon
     }}
   </button>
 
@@ -38,7 +38,7 @@
     {{svg-jar
       "share-variant-outline"
       aria-hidden="true"
-      class=(local-class this.styles "icon")
+      class=this.styles.icon
     }}
   </button>
 </div>

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/app/components/tracks/list/index.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/app/components/tracks/list/index.hbs
@@ -25,7 +25,7 @@
           {{svg-jar
             "alpha-e-box"
             aria-hidden="true"
-            class=(local-class this.styles "icon-explicit")
+            class=this.styles.icon-explicit
           }}
         </span>
       {{/if}}

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/checkbox/index.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/checkbox/index.hbs
@@ -41,7 +41,7 @@
         {{svg-jar
           "check"
           aria-hidden="true"
-          class=(local-class this.styles "checkmark-icon")
+          class=this.styles.checkmark-icon
         }}
       {{/if}}
     </span>

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/captions/index.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/captions/index.hbs
@@ -71,7 +71,7 @@
             {{svg-jar
               "chevron-left"
               aria-hidden="true"
-              class=(local-class this.styles "icon")
+              class=this.styles.icon
             }}
 
           {{/if}}
@@ -93,7 +93,7 @@
             {{svg-jar
               "chevron-right"
               aria-hidden="true"
-              class=(local-class this.styles "icon")
+              class=this.styles.icon
             }}
 
           {{/if}}

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/actions/index.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/actions/index.hbs
@@ -30,7 +30,7 @@
     {{svg-jar
       "heart-outline"
       aria-hidden="true"
-      class=(local-class this.styles "icon")
+      class=this.styles.icon
     }}
   </button>
 
@@ -38,7 +38,7 @@
     {{svg-jar
       "share-variant-outline"
       aria-hidden="true"
-      class=(local-class this.styles "icon")
+      class=this.styles.icon
     }}
   </button>
 </div>

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/app/components/tracks/list.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/app/components/tracks/list.hbs
@@ -25,7 +25,7 @@
           {{svg-jar
             "alpha-e-box"
             aria-hidden="true"
-            class=(local-class this.styles "icon-explicit")
+            class=this.styles.icon-explicit
           }}
         </span>
       {{/if}}

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/app/components/ui/form/checkbox.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/app/components/ui/form/checkbox.hbs
@@ -41,7 +41,7 @@
         {{svg-jar
           "check"
           aria-hidden="true"
-          class=(local-class this.styles "checkmark-icon")
+          class=this.styles.checkmark-icon
         }}
       {{/if}}
     </span>

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/app/components/widgets/widget-2/captions.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/app/components/widgets/widget-2/captions.hbs
@@ -71,7 +71,7 @@
             {{svg-jar
               "chevron-left"
               aria-hidden="true"
-              class=(local-class this.styles "icon")
+              class=this.styles.icon
             }}
 
           {{/if}}
@@ -93,7 +93,7 @@
             {{svg-jar
               "chevron-right"
               aria-hidden="true"
-              class=(local-class this.styles "icon")
+              class=this.styles.icon
             }}
 
           {{/if}}

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/app/components/widgets/widget-4/memo/actions.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/ember-container-query-typescript/output/app/components/widgets/widget-4/memo/actions.hbs
@@ -30,7 +30,7 @@
     {{svg-jar
       "heart-outline"
       aria-hidden="true"
-      class=(local-class this.styles "icon")
+      class=this.styles.icon
     }}
   </button>
 
@@ -38,7 +38,7 @@
     {{svg-jar
       "share-variant-outline"
       aria-hidden="true"
-      class=(local-class this.styles "icon")
+      class=this.styles.icon
     }}
   </button>
 </div>

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-component-templates/glint/output/app/components/test-case-20.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-component-templates/glint/output/app/components/test-case-20.hbs
@@ -4,7 +4,7 @@
   same so that the end-developer can update it themselves.
 --}}
 {{#let
-  (component "some-component" class=(local-class this.styles "a1"))
+  (component "some-component" class=this.styles.a1)
   as |SomeComponent|
 }}
   <SomeComponent

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-component-templates/glint/output/app/components/test-case-39.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-component-templates/glint/output/app/components/test-case-39.hbs
@@ -7,6 +7,6 @@
   {{svg-jar
     "check"
     aria-hidden="true"
-    class=(local-class this.styles "icon")
+    class=this.styles.icon
   }}
 </button>

--- a/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-component-templates/glint/output/app/components/test-case-41.hbs
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/fixtures/steps/update-component-templates/glint/output/app/components/test-case-41.hbs
@@ -3,6 +3,6 @@
   that we invoke with the curly-brace syntax.
 }}
 {{input
-  class=(local-class this.styles "input")
+  class=this.styles.input
   value=value
 }}

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/update-component-templates/glint.test.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/update-component-templates/glint.test.ts
@@ -66,13 +66,7 @@ test('migration | ember-app | steps | update-component-templates > glint', funct
 
       assertFixture(outputProjectLocalized, codemodOptions);
     }
-  } catch (error) {
-    let message = `${fileName} failed.`;
-
-    if (error instanceof Error) {
-      message = error.message;
-    }
-
-    assert.fail(`${message}\n`);
+  } catch {
+    assert.fail(`${fileName} failed.\n`);
   }
 });

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/update-component-templates/nested.test.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/update-component-templates/nested.test.ts
@@ -74,13 +74,7 @@ test('migration | ember-app | steps | update-component-templates > nested', func
 
       assertFixture(outputProjectLocalized, codemodOptions);
     }
-  } catch (error) {
-    let message = `${folderName} failed.`;
-
-    if (error instanceof Error) {
-      message = error.message;
-    }
-
-    assert.fail(`${message}\n`);
+  } catch {
+    assert.fail(`${folderName} failed.\n`);
   }
 });

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/update-route-templates/glint.test.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/update-route-templates/glint.test.ts
@@ -67,13 +67,7 @@ test('migration | ember-app | steps | update-route-templates > glint', function 
 
       assertFixture(outputProjectLocalized, codemodOptions);
     }
-  } catch (error) {
-    let message = `${fileName} failed.`;
-
-    if (error instanceof Error) {
-      message = error.message;
-    }
-
-    assert.fail(`${message}\n`);
+  } catch {
+    assert.fail(`${fileName} failed.\n`);
   }
 });

--- a/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/update-route-templates/nested.test.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/tests/migration/ember-app/steps/update-route-templates/nested.test.ts
@@ -67,13 +67,7 @@ test('migration | ember-app | steps | update-route-templates > nested', function
 
       assertFixture(outputProjectLocalized, codemodOptions);
     }
-  } catch (error) {
-    let message = `${fileName} failed.`;
-
-    if (error instanceof Error) {
-      message = error.message;
-    }
-
-    assert.fail(`${message}\n`);
+  } catch {
+    assert.fail(`${fileName} failed.\n`);
   }
 });


### PR DESCRIPTION
## Description

In [`ember-container-query#167`](https://github.com/ijlee2/ember-container-query/pull/167), I had documented [3 ways to further optimize the output code](https://github.com/ijlee2/ember-container-query/pull/167/commits/46a354a65990e0298415de7f7e7aaab4fda167ee).

This pull request implements one (1) of these optimizations. Namely, if the `{{local-class}}` helper appears inside a helper and only 1 style is to be applied, we can remove the `{{local-class}}` helper.

```hbs
{{! Before }}
{{svg-jar
  "check"
  aria-hidden="true"
  class=(local-class this.styles "checkmark-icon")
}}
```

```hbs
{{! After }}
{{svg-jar
  "check"
  aria-hidden="true"
  class=this.styles.checkmark-icon
}}
```
