### PR TITLE
Improve documentation

### DIFF
--- a/.changeset/spotty-guests-explode.md
+++ b/.changeset/spotty-guests-explode.md
@@ -1,0 +1,13 @@
+---
+"ember-codemod-remove-ember-css-modules": patch
+"embroider-css-modules-temporary": patch
+"docs-app-for-embroider-css-modules-temporary": patch
+"embroider-css-modules": patch
+"test-app-for-embroider-css-modules": patch
+"docs-app-for-embroider-css-modules": patch
+"type-css-modules": patch
+"test-app-for-sample-v2-addon": patch
+"sample-v2-addon": patch
+---
+
+Improved documentation

--- a/docs/embroider-css-modules-temporary/README.md
+++ b/docs/embroider-css-modules-temporary/README.md
@@ -1,31 +1,57 @@
 [![This project uses GitHub Actions for continuous integration.](https://github.com/ijlee2/embroider-css-modules/actions/workflows/ci.yml/badge.svg)](https://github.com/ijlee2/embroider-css-modules/actions/workflows/ci.yml)
+[![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/Isaac/embroider-css-modules)
 
 # docs-app-for-embroider-css-modules-temporary
+
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+1. [Compatibility](#compatibility)
+1. [Contributing](#contributing)
+1. [License](#license)
+
+
+## What is it?
 
 `docs-app-for-embroider-css-modules-temporary` is an Ember app. We use it to check that `ember-css-modules` and `embroider-css-modules-temporary` can coexist.
 
 
 ## Local development
 
-Before starting the application, build the `embroider-css-modules-temporary` package so that the app can test the latest code.
+Before starting the application, build its dependencies so that you can test the latest code.
 
 ```sh
 # From the workspace root
-cd packages/embroider-css-modules-temporary
 pnpm build
 
 # Change directory
-cd ../../docs/embroider-css-modules-temporary
+cd docs/embroider-css-modules-temporary
+```
+
+Some useful commands:
+
+```sh
+# Run the app
 pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
 pnpm test
 ```
 
 
 ## Compatibility
 
-* Node.js v16 or above
+- Node.js v16 or above
 
 
 ## Contributing
 
 See the [Contributing](../../CONTRIBUTING.md) guide for details.
+
+
+## License
+
+This project is licensed under the [MIT License](../../LICENSE.md).

--- a/docs/embroider-css-modules/README.md
+++ b/docs/embroider-css-modules/README.md
@@ -3,33 +3,57 @@
 
 # docs-app-for-embroider-css-modules
 
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+    - [One-line `start` command](#one-line-start-command)
+1. [Compatibility](#compatibility)
+1. [Contributing](#contributing)
+1. [License](#license)
+
+
+## What is it?
+
 `docs-app-for-embroider-css-modules` is an Ember app. We use it to check that `embroider-css-modules` is compatible with "bleeding-edge" Ember:
 
 - [Embroider on the strictest settings](https://github.com/embroider-build/embroider/#options) (including route splitting)
 - [Glint](https://typed-ember.gitbook.io/glint/)
 - [`<template>` tag](https://github.com/ember-template-imports/ember-template-imports)
 
-In addition, the component and route templates, the application tests (visual regression tests), and the rendering tests serve as a living documentation for `embroider-css-modules`.
+In addition, the component and route templates, the application tests (visual regression tests), and the rendering tests serve as a living documentation.
 
 Lastly, end-developers can check the [deployed app](https://embroider-css-modules.netlify.app/) (do a "test drive") before they decide to introduce CSS modules to their projects.
 
 
 ## Local development
 
-Before starting the application, build the `embroider-css-modules` package so that the app can test the latest code.
+Before starting the application, build its dependencies so that you can test the latest code.
 
 ```sh
 # From the workspace root
-cd packages/embroider-css-modules
 pnpm build
 
 # Change directory
-cd ../../docs/embroider-css-modules
+cd docs/embroider-css-modules
+```
+
+Some useful commands:
+
+```sh
+# Run the app
 pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
 pnpm test
 ```
 
-Alternatively, you can run the application with 1 command:
+
+### One-line start command
+
+With 1 command, you can build the dependencies and start the app:
 
 ```sh
 # From the workspace root
@@ -39,9 +63,14 @@ pnpm start
 
 ## Compatibility
 
-* Node.js v16 or above
+- Node.js v16 or above
 
 
 ## Contributing
 
 See the [Contributing](../../CONTRIBUTING.md) guide for details.
+
+
+## License
+
+This project is licensed under the [MIT License](../../LICENSE.md).

--- a/docs/sample-v2-addon/README.md
+++ b/docs/sample-v2-addon/README.md
@@ -1,30 +1,49 @@
 [![This project uses GitHub Actions for continuous integration.](https://github.com/ijlee2/embroider-css-modules/actions/workflows/ci.yml/badge.svg)](https://github.com/ijlee2/embroider-css-modules/actions/workflows/ci.yml)
+[![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/Isaac/embroider-css-modules)
 
 # sample-v2-addon
+
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+1. [Compatibility](#compatibility)
+1. [Contributing](#contributing)
+
+
+## What is it?
 
 `sample-v2-addon` is an Ember addon. We use it to check that `embroider-css-modules` is compatible with v2 addons.
 
 
 ## Local development
 
-Before starting the application, build the `embroider-css-modules` package so that the addon can test the latest code.
+After making a code change, build the addon so that consuming apps can test the latest code.
 
 ```sh
-# From the workspace root
-cd packages/embroider-css-modules
 pnpm build
+```
 
-# Change directory
-cd ../../docs/sample-v2-addon
-pnpm build
+Some useful commands:
+
+```sh
+# Keep the addon running (live reload)
+pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
 ```
 
 
 ## Compatibility
 
-* Node.js v16 or above
+- Node.js v16 or above
 
 
 ## Contributing
 
 See the [Contributing](../../CONTRIBUTING.md) guide for details.
+
+
+## License
+
+This project is licensed under the [MIT License](../../LICENSE.md).

--- a/docs/written-guides/set-up-css-modules-apps.md
+++ b/docs/written-guides/set-up-css-modules-apps.md
@@ -12,8 +12,9 @@ We will use Webpack and PostCSS to implement CSS modules. (If you get lost, you 
 1. [Style your first component](#style-your-first-component)
     - [Glimmer components](#glimmer-components)
     - [&lt;template&gt;-tag components](#template-tag-components)
-    - [Do the file location and name matter?](#do-the-file-location-and-name-matter)
     - [CSS declaration files](#css-declaration-files)
+    - [Do the file location and name matter?](#do-the-file-location-and-name-matter)
+    - [Can I use the file extension `*.module.css`?](#can-i-use-the-file-extension-modulecss)
     - [Write tests](#write-tests)
 1. [Style your first route](#style-your-first-route)
     - [Do the file location and name matter?](#do-the-file-location-and-name-matter-1)
@@ -373,7 +374,7 @@ You can also [apply multiple styles with the `{{local-class}}` helper](../../pac
 
 You may have noticed a downside of `embroider-css-modules`. Since we pass `styles` to the template as a class property, it's not possible to style template-only components.
 
-We can easily address this issue by writing [`<template>`-tag components](https://github.com/ember-template-imports/ember-template-imports). Replace `hello-world.{hbs,ts}` with `hello-world.gts`:
+We can address this issue by writing [`<template>`-tag components](https://github.com/ember-template-imports/ember-template-imports). Replace `hello-world.{hbs,ts}` with `hello-world.gts`:
 
 <details>
 
@@ -390,6 +391,42 @@ import styles from './hello-world.css';
 ```
 
 </details>
+
+
+### CSS declaration files
+
+To help TypeScript understand what it means to import a CSS file,
+
+```ts
+import styles from './hello-world.css';
+```
+
+and what `styles` looks like, you will need to provide the declaration file `hello-world.css.d.ts`.
+
+Lucky for you, [`type-css-modules`](../../packages/type-css-modules) can create this file. Write a pre-script as shown below:
+
+```json5
+/* package.json */
+{
+  "scripts": {
+    "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:types": "tsc --noEmit", // or "glint"
+    "prelint:types": "type-css-modules --src app"
+  }
+}
+```
+
+Now, when you run `lint`, the `prelint:types` script will create the CSS declaration file(s), then `lint:types` will type-check the files in your project.
+
+```sh
+pnpm lint
+```
+
+If the `lint` script takes too long to run, you can run just `prelint:types` to create the declaration files.
+
+```sh
+pnpm prelint:types
+```
 
 
 ### Do the file location and name matter?
@@ -429,40 +466,16 @@ your-ember-app
 ```
 
 
-### CSS declaration files
+### Can I use the file extension \*.module.css?
 
-To help TypeScript understand what it means to import a CSS file,
+Yes! You may use `*.module.css` to indicate the stylesheets that are for CSS modules. `type-css-modules` will create declaration files with the extension `*.module.css.d.ts`.
 
-```ts
-import styles from './hello-world.css';
+```diff
+- import styles from './hello-world.css';
++ import styles from './hello-world.module.css';
 ```
 
-and what `styles` looks like, you will need to provide the declaration file `hello-world.css.d.ts`.
-
-Lucky for you, [`type-css-modules`](../../packages/type-css-modules) can create this file. Write a pre-script as shown below:
-
-```json5
-/* package.json */
-{
-  "scripts": {
-    "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
-    "lint:types": "tsc --noEmit", // or "glint"
-    "prelint:types": "type-css-modules --src app"
-  }
-}
-```
-
-Now, when you run the `lint` script, the `prelint:types` script will create the CSS declaration file(s), then `lint:types` will type-check the files in your project.
-
-```sh
-pnpm lint
-```
-
-If the `lint` script takes long to run, you can run just `prelint:types` to create the declaration files.
-
-```sh
-pnpm prelint:types
-```
+⚠️ The files `app/assets/app.css` and `app/styles/app.css` keep the extension `*.css`.
 
 
 ### Write tests

--- a/docs/written-guides/set-up-css-modules-v2-addons.md
+++ b/docs/written-guides/set-up-css-modules-v2-addons.md
@@ -9,8 +9,9 @@ We will use Rollup and PostCSS to implement CSS modules. (If you get lost, you c
 1. [Style your first component](#style-your-first-component)
     - [Glimmer components](#glimmer-components)
     - [&lt;template&gt;-tag components](#template-tag-components)
-    - [Do the file location and name matter?](#do-the-file-location-and-name-matter)
     - [CSS declaration files](#css-declaration-files)
+    - [Do the file location and name matter?](#do-the-file-location-and-name-matter)
+    - [Can I use the file extension `*.module.css`?](#can-i-use-the-file-extension-modulecss)
     - [Write tests](#write-tests)
 
 
@@ -393,7 +394,7 @@ You can also [apply multiple styles with the `{{local-class}}` helper](../../pac
 
 You may have noticed a downside of `embroider-css-modules`. Since we pass `styles` to the template as a class property, it's not possible to style template-only components.
 
-We can easily address this issue by writing [`<template>`-tag components](https://github.com/ember-template-imports/ember-template-imports).<sup>1</sup> Replace `navigation-menu.{hbs,ts}` with `navigation-menu.gts`:
+We can address this issue by writing [`<template>`-tag components](https://github.com/ember-template-imports/ember-template-imports).<sup>1</sup> Replace `navigation-menu.{hbs,ts}` with `navigation-menu.gts`:
 
 <details>
 
@@ -440,28 +441,6 @@ export default NavigationMenuComponent;
 <sup>1. You need [`rollup-plugin-glimmer-template-tag`](https://github.com/NullVoxPopuli/rollup-plugin-glimmer-template-tag) to write `*.{gjs,gts}` files in a v2 addon.</sup>
 
 
-### Do the file location and name matter?
-
-In Ember v4.12, a component's template and backing class must have the same name (the related technical terms are [resolve and resolution](https://github.com/ember-cli/ember-resolver)):
-
-- `navigation-menu.{hbs,ts}`
-
-In contrast, the component's stylesheet can have a different name and even live in a different folder. This is because we explicitly import the CSS file in the backing class.
-
-Still, for everyone's sanity, I recommend colocating the stylesheet and providing the same name.
-
-```sh
-your-v2-addon
-├── src
-│   └── components
-│       ├── navigation-menu.css
-│       ├── navigation-menu.css.d.ts
-│       ├── navigation-menu.hbs
-│       └── navigation-menu.ts
-...
-```
-
-
 ### CSS declaration files
 
 To help TypeScript understand what it means to import a CSS file,
@@ -485,16 +464,48 @@ Lucky for you, [`type-css-modules`](../../packages/type-css-modules) can create 
 }
 ```
 
-Now, when you run the `lint` script, the `prelint:types` script will create the CSS declaration file(s), then `lint:types` will type-check the files in your project.
+Now, when you run `lint`, the `prelint:types` script will create the CSS declaration file(s), then `lint:types` will type-check the files in your project.
 
 ```sh
 pnpm lint
 ```
 
-If the `lint` script takes long to run, you can run just `prelint:types` to create the declaration files.
+If the `lint` script takes too long to run, you can run just `prelint:types` to create the declaration files.
 
 ```sh
 pnpm prelint:types
+```
+
+
+### Do the file location and name matter?
+
+In Ember v4.12, a component's template and backing class must have the same name (the related technical terms are [resolve and resolution](https://github.com/ember-cli/ember-resolver)):
+
+- `navigation-menu.{hbs,ts}`
+
+In contrast, the component's stylesheet can have a different name and even live in a different folder. This is because we explicitly import the CSS file in the backing class.
+
+Still, for everyone's sanity, I recommend colocating the stylesheet and providing the same name.
+
+```sh
+your-v2-addon
+├── src
+│   └── components
+│       ├── navigation-menu.css
+│       ├── navigation-menu.css.d.ts
+│       ├── navigation-menu.hbs
+│       └── navigation-menu.ts
+...
+```
+
+
+### Can I use the file extension \*.module.css?
+
+Yes! You may use `*.module.css` to indicate the stylesheets that are for CSS modules. `type-css-modules` will create declaration files with the extension `*.module.css.d.ts`.
+
+```diff
+- import styles from './navigation-menu.css';
++ import styles from './navigation-menu.module.css';
 ```
 
 
@@ -536,6 +547,6 @@ module('Integration | Component | navigation-menu', function (hooks) {
 
 </details>
 
-<sup>1. It's assumed that [`rollup-plugin-postcss` creates "predictable" hashes](#update-rollupconfigmjs) (either `modules.generateScopedName: <package-name>__[path][name]__[local]'` or `modules: true`).</sup>
+<sup>1. To make weak assertions, `rollup-plugin-postcss` must create ["predictable" hashes](#update-rollupconfigmjs).</sup>
 
 <sup>2. We can write `assert.dom('ul').hasClass(styles.list)` and `assert.dom('a').hasClass(styles.link)`, if we can [find a way to import a v2 addon's stylesheet](#update-packagejson).</sup>

--- a/packages/ember-codemod-remove-ember-css-modules/README.md
+++ b/packages/ember-codemod-remove-ember-css-modules/README.md
@@ -4,6 +4,17 @@
 
 _Codemod to replace `ember-css-modules` with `embroider-css-modules`_
 
+1. [Features](#features)
+1. [Usage](#usage)
+    - [Arguments](#arguments)
+    - [Limitations](#limitations)
+1. [How to refactor code](#how-to-refactor-code)
+    - [Remove code inheritance](#remove-code-inheritance)
+    - [Remove complex string concatenations](#remove-complex-string-concatenations)
+1. [Compatibility](#compatibility)
+1. [Contributing](#contributing)
+1. [License](#license)
+
 
 ## Features
 
@@ -217,7 +228,7 @@ The codemod may fail to update complex expressions. Refactor templates to provid
 
 ## Compatibility
 
-* Node.js v16 or above
+- Node.js v16 or above
 
 
 ## Contributing

--- a/packages/embroider-css-modules-temporary/README.md
+++ b/packages/embroider-css-modules-temporary/README.md
@@ -5,6 +5,12 @@
 
 `embroider-css-modules` with renamed `{{local-class}}` helper
 
+1. [Why use this package?](#why-use-this-package)
+1. [API](#api)
+1. [Installation](#installation)
+1. [Contributing](#contributing)
+1. [License](#license)
+
 
 ## Why use this package?
 
@@ -35,7 +41,10 @@ Once the migration is complete:
 - Replace `embroider-css-modules-temporary` with `embroider-css-modules`
 - Rename `{{local-class-new}}` to `{{local-class}}`
 
-More information about API and compatible versions can be found in [`embroider-css-modules`](../embroider-css-modules).
+
+## API
+
+Information about API and compatible versions can be found in [`embroider-css-modules`](../embroider-css-modules).
 
 
 ## Installation

--- a/packages/embroider-css-modules/README.md
+++ b/packages/embroider-css-modules/README.md
@@ -5,6 +5,14 @@
 
 _CSS modules for Embroider + TypeScript projects_
 
+1. [What is it?](#what-is-it)
+1. [Installation](#installation)
+1. [API](#api)
+    - [Helper: `{{local-class}}`](#helper-local-class)
+1. [Compatibility](#compatibility)
+1. [Contributing](#contributing)
+1. [License](#license)
+
 
 ## What is it?
 
@@ -71,7 +79,7 @@ The addon provides 1 helper:
 
 - `{{local-class}}`
 
-Expand the items below to learn more about the API. Throughout the section, you can assume that there is a `styles` object, which maps local class names to global ones.
+Throughout the section, you can assume that there is a `styles` object, which maps local class names to global ones.
 
 ```ts
 // An example
@@ -83,15 +91,19 @@ const styles = {
 };
 ```
 
-<details>
-<summary><code>{{local-class}}</code></summary>
 
-### Why use it?
+### Helper: {{local-class}}
+
+#### Why use it?
 
 The `{{local-class}}` helper is useful when you want to apply multiple styles.
 
+<details>
+
+<summary>Before: With the <code>{{concat}}</code> helper</summary>
+
 ```hbs
-{{! Before: app/components/ui/form/field.hbs }}
+{{! app/components/ui/form/field.hbs }}
 <div
   class={{concat
     this.styles.container
@@ -107,8 +119,14 @@ The `{{local-class}}` helper is useful when you want to apply multiple styles.
 </div>
 ```
 
+</details>
+
+<details>
+
+<summary>After: With the <code>{{local-class}}</code> helper</summary>
+
 ```hbs
-{{! After: app/components/ui/form/field.hbs }}
+{{! app/components/ui/form/field.hbs }}
 <div
   class={{local-class
     this.styles
@@ -122,7 +140,13 @@ The `{{local-class}}` helper is useful when you want to apply multiple styles.
 </div>
 ```
 
+</details>
+
 To apply multiple styles when a conditional statement holds, use the `{{array}}` helper.
+
+<details>
+
+<summary>Example</summary>
 
 ```hbs
 {{! app/templates/products.hbs }}
@@ -141,24 +165,24 @@ To apply multiple styles when a conditional statement holds, use the `{{array}}`
 </div>
 ```
 
-### Arguments
+</details>
 
-The `{{local-class}}` helper uses positional arguments so that styles are applied in sequence.
 
-Pass the `styles` object first, then the local class name(s).
+#### Arguments
 
-### Outputs
+The `{{local-class}}` helper uses positional arguments so that styles are applied in sequence. Pass the `styles` object first, then the local class name(s).
+
+
+#### Outputs
 
 The `{{local-class}}` helper returns a concatenated string. The string lists the global class names in the same order as the local ones.
-
-</details>
 
 
 ## Compatibility
 
-* `ember-auto-import@v2`<sup>1</sup>
-* Ember.js v4.4 or above<sup>2</sup>
-* Node.js v16 or above
+- `ember-auto-import@v2`<sup>1</sup>
+- Ember.js v4.4 or above<sup>2</sup>
+- Node.js v16 or above
 
 <sup>1. `embroider-css-modules` is a v2 addon. This means, your project must have `ember-auto-import@v2`. If you are momentarily stuck with `ember-auto-import@v1`, you can use [`ember-css-modules`](https://github.com/salsify/ember-css-modules) to implement CSS modules.</sup>
 

--- a/packages/type-css-modules/README.md
+++ b/packages/type-css-modules/README.md
@@ -376,7 +376,7 @@ import { container, header, body } from './page.css';
 
 ## Compatibility
 
-* Node.js v16 or above
+- Node.js v16 or above
 
 
 ## Contributing

--- a/packages/type-css-modules/README.md
+++ b/packages/type-css-modules/README.md
@@ -4,6 +4,16 @@
 
 _Generate declaration files for CSS modules_ (independent of JavaScript framework)
 
+1. [Why use this package?](#why-use-this-package)
+1. [How to use this package?](#how-to-use-this-package)
+    - [Arguments](#arguments)
+    - [Use Prettier?](#use-prettier)
+    - [Can I use the file extension `*.module.css`?](#can-i-use-the-file-extension-modulecss)
+1. [Limitations](#limitations)
+1. [Compatibility](#compatibility)
+1. [Contributing](#contributing)
+1. [License](#license)
+
 
 ## Why use this package?
 
@@ -21,13 +31,11 @@ First, you will run into poor developer experience (DX) when [`noPropertyAccessF
 
 <details>
 
-<summary>Examples</summary>
-
-Component in Ember:
+<summary>Ember: Glimmer component</summary>
 
 ```hbs
 {{! app/components/ui/page.hbs }}
-{{! This should work but results in an error }}
+{{! This should work, but results in an error. }}
 <div class={{this.styles.container}}>
   {{!-- ↳ Property 'container' comes from an index signature, so it must be accessed with {{get ... 'container'}}. --}}
 </div>
@@ -37,14 +45,18 @@ Component in Ember:
 </div>
 ```
 
-Component in Ember, with `<template>` tag:
+</details>
+
+<details>
+
+<summary>Ember: <code>template</code>-tag component</summary>
 
 ```ts
 /* app/components/ui/page.gts */
 import styles from './page.css';
 
 <template>
-  // This should work but results in an error
+  // This should work, but results in an error.
   <div class={{styles.container}}>
     // ↳ Property 'container' comes from an index signature, so it must be accessed with ['container'].
   </div>
@@ -61,13 +73,13 @@ Second, the loose definition may be incompatible with libraries that provide typ
 
 <details>
 
-<summary>Example</summary>
+<summary>Ember: Rendering test</summary>
 
 ```ts
 /* tests/integration/components/ui/page-test.ts */
 import styles from 'app/components/ui/page.css';
 
-// This should work but results in an error
+// This should work, but results in an error.
 assert
   .dom('[data-test-container]')
   .hasClass(styles.container);
@@ -86,7 +98,7 @@ When you provide accurate types, libraries (e.g. [`Glint`](https://typed-ember.g
 
 <details>
 
-<summary>Example</summary>
+<summary>Ember: Glimmer component</summary>
 
 ```hbs
 {{! app/components/ui/page.hbs }}
@@ -106,14 +118,7 @@ When you provide accurate types, libraries (e.g. [`Glint`](https://typed-ember.g
 
 ## How to use this package?
 
-Option 1 (one-time use). Use `npx` to run `type-css-modules`.
-
-```sh
-cd <path/to/your/project>
-npx type-css-modules <arguments>
-```
-
-Option 2 (recommended). Install `type-css-modules` as a development dependency. Ensure that the CSS declaration files exist before checking the types; for example, you can write a [pre-script](https://docs.npmjs.com/cli/v9/using-npm/scripts#pre--post-scripts).
+Option 1 (recommended). Install `type-css-modules` as a development dependency. Ensure that the CSS declaration files exist before checking the types; for example, you can write a [pre-script](https://docs.npmjs.com/cli/v9/using-npm/scripts#pre--post-scripts).
 
 ```json5
 /* package.json */
@@ -127,6 +132,13 @@ Option 2 (recommended). Install `type-css-modules` as a development dependency. 
     "typescript": "..."
   }
 }
+```
+
+Option 2 (one-time use). Use `npx` to run `type-css-modules`.
+
+```sh
+cd <path/to/your/project>
+npx type-css-modules <arguments>
 ```
 
 
@@ -173,7 +185,14 @@ module.exports = {
     },
   ],
 };
-````
+```
+
+
+### Can I use the file extension \*.module.css?
+
+Good news! You can continue to use `*.module.css` to indicate the stylesheets that are for CSS modules.
+
+`type-css-modules` will create declaration files with the extension `*.module.css.d.ts`. The [Prettier configuration](#use-prettier) shown above can remain as is.
 
 
 ## Limitations
@@ -188,7 +207,7 @@ Here are some examples that meet the syntax requirements.
 
 <details>
 
-<summary>Ember + TypeScript</summary>
+<summary>Ember: Glimmer component</summary>
 
 ```css
 /* app/components/ui/page.css */
@@ -242,7 +261,7 @@ export default class UiPageComponent extends Component {
 
 <details>
 
-<summary>Ember + TypeScript + <code>&lt;template&gt;</code> tag</summary>
+<summary>Ember: <code>&lt;template&gt;</code>-tag component</summary>
 
 ```ts
 /* app/components/ui/page.gts */
@@ -350,9 +369,9 @@ import { container, header, body } from './page.css';
 
 </details>
 
-<sup>1. With `webpack`, for example, you can configure [`mode`](https://webpack.js.org/loaders/css-loader/#mode) to be a function that returns `'local'` or `'global'`. In CSS module files, you can use the `:global()` pseudo-class selector to refer to "things from outside."</sup>
+<sup>1. With `webpack`, for example, you can configure [`mode`](https://webpack.js.org/loaders/css-loader/#mode) to be a function that returns `'local'` or `'global'`. In CSS module stylesheets, you can use the `:global()` pseudo-class selector to refer to "things from outside."</sup>
 
-<sup>2. [CSS nesting is in spec](https://www.w3.org/TR/css-nesting-1/). Once it is official, `type-css-modules` will leave it up to [`csstree`](https://github.com/csstree/csstree) to parse nested styles.
+<sup>2. [CSS nesting is in spec](https://www.w3.org/TR/css-nesting-1/). Once it is official, `type-css-modules` will leave it up to [`CSSTree`](https://github.com/csstree/csstree) to parse nested styles.
 
 
 ## Compatibility

--- a/tests/embroider-css-modules/README.md
+++ b/tests/embroider-css-modules/README.md
@@ -2,6 +2,15 @@
 
 # test-app-for-embroider-css-modules
 
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+1. [Compatibility](#compatibility)
+1. [Contributing](#contributing)
+1. [License](#license)
+
+
+## What is it?
+
 `test-app-for-embroider-css-modules` is an Ember app. We use it to check that `embroider-css-modules` is compatible with various versions of these projects:
 
 - [Ember](https://emberjs.com/releases/) (long-term support, release, beta, canary)
@@ -10,25 +19,41 @@
 
 ## Local development
 
-Before starting the application, build the `embroider-css-modules` package so that the app can test the latest code.
+Before starting the application, build its dependencies so that you can test the latest code.
 
 ```sh
 # From the workspace root
-cd packages/embroider-css-modules
 pnpm build
 
 # Change directory
-cd ../../tests/embroider-css-modules
+cd tests/embroider-css-modules
+```
+
+Some useful commands:
+
+```sh
+# Run the app
 pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
 pnpm test
 ```
 
 
 ## Compatibility
 
-* Node.js v16 or above
+- Node.js v16 or above
 
 
 ## Contributing
 
 See the [Contributing](../../CONTRIBUTING.md) guide for details.
+
+
+## License
+
+This project is licensed under the [MIT License](../../LICENSE.md).

--- a/tests/sample-v2-addon/README.md
+++ b/tests/sample-v2-addon/README.md
@@ -2,6 +2,15 @@
 
 # test-app-for-sample-v2-addon
 
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+1. [Compatibility](#compatibility)
+1. [Contributing](#contributing)
+1. [License](#license)
+
+
+## What is it?
+
 `test-app-for-sample-v2-addon` is an Ember app. We use it to check that `sample-v2-addon` is compatible with various versions of these projects:
 
 - [Ember](https://emberjs.com/releases/) (long-term support, release, beta, canary)
@@ -10,25 +19,41 @@
 
 ## Local development
 
-Before starting the application, build the `sample-v2-addon` package so that the app can test the latest code.
+Before starting the application, build its dependencies so that you can test the latest code.
 
 ```sh
 # From the workspace root
-cd docs/sample-v2-addon
 pnpm build
 
 # Change directory
-cd ../../tests/sample-v2-addon
+cd tests/sample-v2-addon
+```
+
+Some useful commands:
+
+```sh
+# Run the app
 pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
 pnpm test
 ```
 
 
 ## Compatibility
 
-* Node.js v16 or above
+- Node.js v16 or above
 
 
 ## Contributing
 
 See the [Contributing](../../CONTRIBUTING.md) guide for details.
+
+
+## License
+
+This project is licensed under the [MIT License](../../LICENSE.md).


### PR DESCRIPTION
## Description

Follows up on #77 and #78.

In the setup guides, I documented that end-developers may use `*.module.css` to indicate the stylesheets that are for CSS modules. Afterwards, I updated the other `README`'s to bring a consistency in documentation.
