### PR TITLE
Refactor tests

### DIFF
--- a/.changeset/twelve-squids-lay.md
+++ b/.changeset/twelve-squids-lay.md
@@ -1,0 +1,6 @@
+---
+"docs-app-for-embroider-css-modules-temporary": patch
+"docs-app-for-embroider-css-modules": patch
+---
+
+Refactored tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   NODE_VERSION: 16
   PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_number }}
-  PERCY_PARALLEL_TOTAL: 1
+  PERCY_PARALLEL_TOTAL: 2
 
 jobs:
   lint:
@@ -67,6 +67,8 @@ jobs:
           - 'tests/embroider-css-modules'
           - 'tests/sample-v2-addon'
     timeout-minutes: 5
+    env:
+      RUN_PERCY: ${{ matrix.package-location == 'docs/embroider-css-modules' || matrix.package-location == 'docs/embroider-css-modules-temporary' }}
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v3
@@ -87,12 +89,12 @@ jobs:
 
       - name: Test
         run: pnpm test
-        if: ${{ matrix.package-location != 'docs/embroider-css-modules' }}
+        if: ${{ env.RUN_PERCY == 'false' }}
         working-directory: ${{ matrix.package-location }}
 
       - name: Test (w/ visual regression)
         run: npx percy exec -- pnpm test
-        if: ${{ matrix.package-location == 'docs/embroider-css-modules' }}
+        if: ${{ env.RUN_PERCY == 'true' }}
         working-directory: ${{ matrix.package-location }}
         env:
           PERCY_PARALLEL_NONCE: ${{ env.PERCY_PARALLEL_NONCE }}

--- a/docs/embroider-css-modules-temporary/package.json
+++ b/docs/embroider-css-modules-temporary/package.json
@@ -52,6 +52,8 @@
     "@glint/environment-ember-loose": "^1.0.2",
     "@glint/environment-ember-template-imports": "^1.0.2",
     "@glint/template": "^1.0.2",
+    "@percy/cli": "^1.26.0",
+    "@percy/ember": "^4.2.0",
     "@shared-configs/ember-template-lint": "workspace:*",
     "@shared-configs/eslint-config-ember": "workspace:*",
     "@shared-configs/prettier": "workspace:*",

--- a/docs/embroider-css-modules-temporary/tests/acceptance/index/accessibility-test.ts
+++ b/docs/embroider-css-modules-temporary/tests/acceptance/index/accessibility-test.ts
@@ -1,0 +1,15 @@
+import { visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { a11yAudit, setupApplicationTest } from '../../helpers';
+
+module('Acceptance | index', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('Accessibility', async function (assert) {
+    await visit('/');
+    await a11yAudit();
+
+    assert.ok(true);
+  });
+});

--- a/docs/embroider-css-modules-temporary/tests/acceptance/index/as-user-test.ts
+++ b/docs/embroider-css-modules-temporary/tests/acceptance/index/as-user-test.ts
@@ -1,16 +1,13 @@
 import { visit } from '@ember/test-helpers';
-import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '..//helpers';
+import { setupApplicationTest } from '../../helpers';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('it renders', async function (assert) {
+  test('We can visit the page', async function (assert) {
     await visit('/');
-
-    assert.ok(true, 'We visited the index route.');
 
     assert.dom('[data-test-local-class-attribute]').hasStyle(
       {
@@ -32,9 +29,5 @@ module('Acceptance | index', function (hooks) {
       },
       'We can use the {{local-class-new}} helper from embroider-css-modules-temporary.',
     );
-
-    await a11yAudit();
-
-    assert.ok(true, 'We passed Axe tests.');
   });
 });

--- a/docs/embroider-css-modules-temporary/tests/acceptance/index/visual-regression-test.ts
+++ b/docs/embroider-css-modules-temporary/tests/acceptance/index/visual-regression-test.ts
@@ -1,0 +1,17 @@
+import { visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { percySnapshot, setupApplicationTest } from '../../helpers';
+
+module('Acceptance | index', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('Visual regression', async function (assert) {
+    assert.expect(1);
+
+    await visit('/');
+    await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+});

--- a/docs/embroider-css-modules-temporary/tests/helpers/index.ts
+++ b/docs/embroider-css-modules-temporary/tests/helpers/index.ts
@@ -1,3 +1,5 @@
+import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import {
   setupApplicationTest as upstreamSetupApplicationTest,
   setupRenderingTest as upstreamSetupRenderingTest,
@@ -44,4 +46,10 @@ function setupTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // Additional setup for unit tests can be done here.
 }
 
-export { setupApplicationTest, setupRenderingTest, setupTest };
+export {
+  a11yAudit,
+  percySnapshot,
+  setupApplicationTest,
+  setupRenderingTest,
+  setupTest,
+};

--- a/docs/embroider-css-modules/tests/acceptance/dashboard/accessibility-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/dashboard/accessibility-test.ts
@@ -1,17 +1,15 @@
 import { visit } from '@ember/test-helpers';
-import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '../../helpers';
+import { a11yAudit, setupApplicationTest } from '../../helpers';
 
 module('Acceptance | dashboard', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Accessibility audit', async function (assert) {
+  test('Accessibility', async function (assert) {
     await visit('/dashboard');
-
     await a11yAudit();
 
-    assert.ok(true, 'We passed Axe tests.');
+    assert.ok(true);
   });
 });

--- a/docs/embroider-css-modules/tests/acceptance/dashboard/as-user-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/dashboard/as-user-test.ts
@@ -1,0 +1,100 @@
+import { visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../helpers';
+
+module('Acceptance | dashboard', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('We can visit the page', async function (assert) {
+    await visit('/dashboard');
+
+    // Widget 1
+    assert.dom('[data-test-widget="1"]').exists('We see the first widget.');
+
+    // Widget 2
+    assert
+      .dom('[data-test-widget="2"] [data-test-visualization]')
+      .exists('We see the visualization.');
+
+    assert
+      .dom('[data-test-widget="2"] [data-test-captions]')
+      .exists('We see the captions.');
+
+    assert
+      .dom('[data-test-widget="2"] [data-test-field="Music Format"]')
+      .hasText('8 - Track', 'We see the music format in correct format.');
+
+    assert
+      .dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
+      .hasText(
+        'Annual revenue: $2.3 billion',
+        'We see the annual revenue in correct format.',
+      );
+
+    assert
+      .dom('[data-test-widget="2"] [data-test-field="Relevant Years"]')
+      .hasText(
+        'Relevant years: 1973 - 1982',
+        'We see the relevant years in correct format.',
+      );
+
+    assert
+      .dom('[data-test-widget="2"] [data-test-button="Previous"]')
+      .doesNotExist("We don't see the previous button.");
+
+    assert
+      .dom('[data-test-widget="2"] [data-test-button="Next"]')
+      .hasText(
+        'A chevron arrow pointing right',
+        'We see the next button in correct format.',
+      );
+
+    // Widget 3
+    assert
+      .dom('[data-test-widget="3"] [data-test-link="All tours"]')
+      .exists('We see the All tours link.');
+
+    assert
+      .dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute(
+        'src',
+        new RegExp('^/images/widgets/widget-3/.+\\.jpg$'),
+        'We see the concert image.',
+      );
+
+    // Widget 4
+    assert
+      .dom('[data-test-widget="4"] [data-test-link="All memos"]')
+      .exists('We see the All memos link.');
+
+    assert
+      .dom('[data-test-widget="4"] [data-test-memo-header]')
+      .doesNotHaveClass(
+        /minimal-layout/,
+        "The memo header doesn't use the minimal layout.",
+      );
+
+    assert
+      .dom('[data-test-widget="4"] [data-test-memo-body]')
+      .doesNotHaveClass(
+        /minimal-layout/,
+        "The memo body doesn't use the minimal layout.",
+      );
+
+    assert
+      .dom('[data-test-widget="4"] [data-test-memo-actions]')
+      .doesNotHaveClass(
+        /minimal-layout/,
+        "The memo actions doesn't use the minimal layout.",
+      );
+
+    // Widget 5
+    assert
+      .dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText(
+        'What will you create with embroider-css-modules ?',
+        'We see the correct call to action.',
+      );
+  });
+});

--- a/docs/embroider-css-modules/tests/acceptance/dashboard/visual-regression-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/dashboard/visual-regression-test.ts
@@ -1,104 +1,17 @@
-/* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import percySnapshot from '@percy/ember';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '../../helpers';
+import { percySnapshot, setupApplicationTest } from '../../helpers';
 
 module('Acceptance | dashboard', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Visual snapshot', async function (assert) {
+  test('Visual regression', async function (assert) {
+    assert.expect(1);
+
     await visit('/dashboard');
-
-    // Widget 1
-    assert.dom('[data-test-widget="1"]').exists('We see the first widget.');
-
-    // Widget 2
-    assert
-      .dom('[data-test-widget="2"] [data-test-visualization]')
-      .exists('We see the visualization.');
-
-    assert
-      .dom('[data-test-widget="2"] [data-test-captions]')
-      .exists('We see the captions.');
-
-    assert
-      .dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('8 - Track', 'We see the music format in correct format.');
-
-    assert
-      .dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
-      .hasText(
-        'Annual revenue: $2.3 billion',
-        'We see the annual revenue in correct format.',
-      );
-
-    assert
-      .dom('[data-test-widget="2"] [data-test-field="Relevant Years"]')
-      .hasText(
-        'Relevant years: 1973 - 1982',
-        'We see the relevant years in correct format.',
-      );
-
-    assert
-      .dom('[data-test-widget="2"] [data-test-button="Previous"]')
-      .doesNotExist("We don't see the previous button.");
-
-    assert
-      .dom('[data-test-widget="2"] [data-test-button="Next"]')
-      .hasText(
-        'A chevron arrow pointing right',
-        'We see the next button in correct format.',
-      );
-
-    // Widget 3
-    assert
-      .dom('[data-test-widget="3"] [data-test-link="All tours"]')
-      .exists('We see the All tours link.');
-
-    assert
-      .dom('[data-test-widget="3"] [data-test-image="Concert"]')
-      .hasAttribute(
-        'src',
-        new RegExp('^/images/widgets/widget-3/.+\\.jpg$'),
-        'We see the concert image.',
-      );
-
-    // Widget 4
-    assert
-      .dom('[data-test-widget="4"] [data-test-link="All memos"]')
-      .exists('We see the All memos link.');
-
-    assert
-      .dom('[data-test-widget="4"] [data-test-memo-header]')
-      .doesNotHaveClass(
-        /minimal-layout/,
-        "The memo header doesn't use the minimal layout.",
-      );
-
-    assert
-      .dom('[data-test-widget="4"] [data-test-memo-body]')
-      .doesNotHaveClass(
-        /minimal-layout/,
-        "The memo body doesn't use the minimal layout.",
-      );
-
-    assert
-      .dom('[data-test-widget="4"] [data-test-memo-actions]')
-      .doesNotHaveClass(
-        /minimal-layout/,
-        "The memo actions doesn't use the minimal layout.",
-      );
-
-    // Widget 5
-    assert
-      .dom('[data-test-widget="5"] [data-test-call-to-action]')
-      .hasText(
-        'What will you create with embroider-css-modules ?',
-        'We see the correct call to action.',
-      );
-
     await percySnapshot(assert);
+
+    assert.ok(true);
   });
 });

--- a/docs/embroider-css-modules/tests/acceptance/form/accessibility-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/form/accessibility-test.ts
@@ -1,17 +1,15 @@
 import { visit } from '@ember/test-helpers';
-import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '../../helpers';
+import { a11yAudit, setupApplicationTest } from '../../helpers';
 
 module('Acceptance | form', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Accessibility audit', async function (assert) {
+  test('Accessibility', async function (assert) {
     await visit('/form');
-
     await a11yAudit();
 
-    assert.ok(true, 'We passed Axe tests.');
+    assert.ok(true);
   });
 });

--- a/docs/embroider-css-modules/tests/acceptance/form/as-user-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/form/as-user-test.ts
@@ -1,0 +1,22 @@
+import { visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../helpers';
+
+module('Acceptance | form', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('We can visit the page', async function (assert) {
+    await visit('/form');
+
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
+
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+  });
+});

--- a/docs/embroider-css-modules/tests/acceptance/form/visual-regression-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/form/visual-regression-test.ts
@@ -1,26 +1,17 @@
-/* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import percySnapshot from '@percy/ember';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '../../helpers';
+import { percySnapshot, setupApplicationTest } from '../../helpers';
 
 module('Acceptance | form', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Accessibility audit', async function (assert) {
+  test('Visual regression', async function (assert) {
+    assert.expect(1);
+
     await visit('/form');
-
-    assert
-      .dom('[data-test-form="Contact me"]')
-      .exists('We see the contact form.');
-
-    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
-
-    assert
-      .dom('[data-test-button="Submit"]')
-      .hasText('Submit', 'We see the submit button.');
-
     await percySnapshot(assert);
+
+    assert.ok(true);
   });
 });

--- a/docs/embroider-css-modules/tests/acceptance/index/accessibility-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/index/accessibility-test.ts
@@ -1,17 +1,15 @@
 import { visit } from '@ember/test-helpers';
-import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '../../helpers';
+import { a11yAudit, setupApplicationTest } from '../../helpers';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Accessibility audit', async function (assert) {
+  test('Accessibility', async function (assert) {
     await visit('/');
-
     await a11yAudit();
 
-    assert.ok(true, 'We passed Axe tests.');
+    assert.ok(true);
   });
 });

--- a/docs/embroider-css-modules/tests/acceptance/index/as-user-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/index/as-user-test.ts
@@ -1,0 +1,16 @@
+import { visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../helpers';
+
+module('Acceptance | index', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('We can visit the page', async function (assert) {
+    await visit('/');
+
+    assert
+      .dom('[data-test-link="embroider-css-modules"]')
+      .hasClass('controllers-index__code', 'We see the correct class name.');
+  });
+});

--- a/docs/embroider-css-modules/tests/acceptance/index/visual-regression-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/index/visual-regression-test.ts
@@ -1,20 +1,17 @@
-/* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import percySnapshot from '@percy/ember';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '../../helpers';
+import { percySnapshot, setupApplicationTest } from '../../helpers';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Visual snapshot', async function (assert) {
+  test('Visual regression', async function (assert) {
+    assert.expect(1);
+
     await visit('/');
-
-    assert
-      .dom('[data-test-link="embroider-css-modules"]')
-      .hasClass('controllers-index__code');
-
     await percySnapshot(assert);
+
+    assert.ok(true);
   });
 });

--- a/docs/embroider-css-modules/tests/acceptance/not-found/accessibility-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/not-found/accessibility-test.ts
@@ -1,17 +1,15 @@
 import { visit } from '@ember/test-helpers';
-import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '../../helpers';
+import { a11yAudit, setupApplicationTest } from '../../helpers';
 
 module('Acceptance | not-found', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Accessibility audit', async function (assert) {
+  test('Accessibility', async function (assert) {
     await visit('/404');
-
     await a11yAudit();
 
-    assert.ok(true, 'We passed Axe tests.');
+    assert.ok(true);
   });
 });

--- a/docs/embroider-css-modules/tests/acceptance/products/accessibility-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/products/accessibility-test.ts
@@ -1,17 +1,15 @@
 import { visit } from '@ember/test-helpers';
-import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '../../helpers';
+import { a11yAudit, setupApplicationTest } from '../../helpers';
 
 module('Acceptance | products', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Accessibility audit', async function (assert) {
+  test('Accessibility', async function (assert) {
     await visit('/products');
-
     await a11yAudit();
 
-    assert.ok(true, 'We passed Axe tests.');
+    assert.ok(true);
   });
 });

--- a/docs/embroider-css-modules/tests/acceptance/products/as-user-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/products/as-user-test.ts
@@ -1,0 +1,16 @@
+import { visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../helpers';
+
+module('Acceptance | products', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('We can visit the page', async function (assert) {
+    await visit('/products');
+
+    assert
+      .dom('[data-test-product-card]')
+      .exists({ count: 33 }, 'We see 33 products.');
+  });
+});

--- a/docs/embroider-css-modules/tests/acceptance/products/visual-regression-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/products/visual-regression-test.ts
@@ -1,20 +1,17 @@
-/* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import percySnapshot from '@percy/ember';
 import { module, test } from 'qunit';
 
-import { setupApplicationTest } from '../../helpers';
+import { percySnapshot, setupApplicationTest } from '../../helpers';
 
 module('Acceptance | products', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Visual snapshot', async function (assert) {
+  test('Visual regression', async function (assert) {
+    assert.expect(1);
+
     await visit('/products');
-
-    assert
-      .dom('[data-test-product-card]')
-      .exists({ count: 33 }, 'We see 33 products.');
-
     await percySnapshot(assert);
+
+    assert.ok(true);
   });
 });

--- a/docs/embroider-css-modules/tests/helpers/index.ts
+++ b/docs/embroider-css-modules/tests/helpers/index.ts
@@ -1,3 +1,5 @@
+import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import {
   setupApplicationTest as upstreamSetupApplicationTest,
   setupRenderingTest as upstreamSetupRenderingTest,
@@ -44,4 +46,10 @@ function setupTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // Additional setup for unit tests can be done here.
 }
 
-export { setupApplicationTest, setupRenderingTest, setupTest };
+export {
+  a11yAudit,
+  percySnapshot,
+  setupApplicationTest,
+  setupRenderingTest,
+  setupTest,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,12 @@ importers:
       '@glint/template':
         specifier: ^1.0.2
         version: 1.0.2
+      '@percy/cli':
+        specifier: ^1.26.0
+        version: 1.26.0
+      '@percy/ember':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@shared-configs/ember-template-lint':
         specifier: workspace:*
         version: link:../../configs/ember-template-lint
@@ -5065,10 +5071,6 @@ packages:
 
   /@types/node@17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-    dev: true
-
-  /@types/node@20.3.1:
-    resolution: {integrity: sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -12292,7 +12294,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 16.11.7
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true


### PR DESCRIPTION
## Description

In addition to splitting the tests into multiple files, I introduced Percy to `docs-app-for-embroider-css-modules-temporary`. The snapshots will help check that `embroider-css-modules` works for v2 addons.

<img width="900" alt="" src="https://github.com/ijlee2/embroider-css-modules/assets/16869656/374dda8f-6bb7-4d24-ac8a-cbfa98526914">
