### PR TITLE
Provided snapshots a unique name

### DIFF
--- a/.changeset/light-mails-rule.md
+++ b/.changeset/light-mails-rule.md
@@ -1,0 +1,6 @@
+---
+"docs-app-for-embroider-css-modules-temporary": patch
+"docs-app-for-embroider-css-modules": patch
+---
+
+Provided snapshots a unique name

--- a/docs/embroider-css-modules-temporary/tests/acceptance/index/visual-regression-test.ts
+++ b/docs/embroider-css-modules-temporary/tests/acceptance/index/visual-regression-test.ts
@@ -1,7 +1,7 @@
 import { visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
-import { percySnapshot, setupApplicationTest } from '../../helpers';
+import { setupApplicationTest, takeSnapshot } from '../../helpers';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
@@ -10,7 +10,7 @@ module('Acceptance | index', function (hooks) {
     assert.expect(1);
 
     await visit('/');
-    await percySnapshot(assert);
+    await takeSnapshot(assert);
 
     assert.ok(true);
   });

--- a/docs/embroider-css-modules-temporary/tests/helpers/index.ts
+++ b/docs/embroider-css-modules-temporary/tests/helpers/index.ts
@@ -1,4 +1,3 @@
-import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import {
   setupApplicationTest as upstreamSetupApplicationTest,
@@ -6,6 +5,8 @@ import {
   setupTest as upstreamSetupTest,
 } from 'ember-qunit';
 import type Resolver from 'ember-resolver';
+
+import { takeSnapshot } from './percy';
 
 interface SetupTestOptions {
   resolver?: Resolver | undefined;
@@ -48,8 +49,8 @@ function setupTest(hooks: NestedHooks, options?: SetupTestOptions) {
 
 export {
   a11yAudit,
-  percySnapshot,
   setupApplicationTest,
   setupRenderingTest,
   setupTest,
+  takeSnapshot,
 };

--- a/docs/embroider-css-modules-temporary/tests/helpers/percy.ts
+++ b/docs/embroider-css-modules-temporary/tests/helpers/percy.ts
@@ -1,0 +1,26 @@
+import percySnapshot from '@percy/ember';
+
+type QUnitAssert = {
+  test: {
+    module: {
+      name: string;
+    };
+    testName: string;
+  };
+};
+
+function getName(qunitAssert: QUnitAssert): string {
+  const packageName = 'docs-app-for-embroider-css-modules-temporary';
+  const moduleName = qunitAssert.test.module.name;
+  const testName = qunitAssert.test.testName;
+
+  const name = `${moduleName} | ${testName} (${packageName})`;
+
+  return name;
+}
+
+export async function takeSnapshot(qunitAssert: unknown): Promise<void> {
+  const name = getName(qunitAssert as QUnitAssert);
+
+  await percySnapshot(name);
+}

--- a/docs/embroider-css-modules/tests/acceptance/dashboard/visual-regression-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/dashboard/visual-regression-test.ts
@@ -1,7 +1,7 @@
 import { visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
-import { percySnapshot, setupApplicationTest } from '../../helpers';
+import { setupApplicationTest, takeSnapshot } from '../../helpers';
 
 module('Acceptance | dashboard', function (hooks) {
   setupApplicationTest(hooks);
@@ -10,7 +10,7 @@ module('Acceptance | dashboard', function (hooks) {
     assert.expect(1);
 
     await visit('/dashboard');
-    await percySnapshot(assert);
+    await takeSnapshot(assert);
 
     assert.ok(true);
   });

--- a/docs/embroider-css-modules/tests/acceptance/form/visual-regression-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/form/visual-regression-test.ts
@@ -1,7 +1,7 @@
 import { visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
-import { percySnapshot, setupApplicationTest } from '../../helpers';
+import { setupApplicationTest, takeSnapshot } from '../../helpers';
 
 module('Acceptance | form', function (hooks) {
   setupApplicationTest(hooks);
@@ -10,7 +10,7 @@ module('Acceptance | form', function (hooks) {
     assert.expect(1);
 
     await visit('/form');
-    await percySnapshot(assert);
+    await takeSnapshot(assert);
 
     assert.ok(true);
   });

--- a/docs/embroider-css-modules/tests/acceptance/index/visual-regression-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/index/visual-regression-test.ts
@@ -1,7 +1,7 @@
 import { visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
-import { percySnapshot, setupApplicationTest } from '../../helpers';
+import { setupApplicationTest, takeSnapshot } from '../../helpers';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
@@ -10,7 +10,7 @@ module('Acceptance | index', function (hooks) {
     assert.expect(1);
 
     await visit('/');
-    await percySnapshot(assert);
+    await takeSnapshot(assert);
 
     assert.ok(true);
   });

--- a/docs/embroider-css-modules/tests/acceptance/products/visual-regression-test.ts
+++ b/docs/embroider-css-modules/tests/acceptance/products/visual-regression-test.ts
@@ -1,7 +1,7 @@
 import { visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
-import { percySnapshot, setupApplicationTest } from '../../helpers';
+import { setupApplicationTest, takeSnapshot } from '../../helpers';
 
 module('Acceptance | products', function (hooks) {
   setupApplicationTest(hooks);
@@ -10,7 +10,7 @@ module('Acceptance | products', function (hooks) {
     assert.expect(1);
 
     await visit('/products');
-    await percySnapshot(assert);
+    await takeSnapshot(assert);
 
     assert.ok(true);
   });

--- a/docs/embroider-css-modules/tests/helpers/index.ts
+++ b/docs/embroider-css-modules/tests/helpers/index.ts
@@ -1,4 +1,3 @@
-import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import {
   setupApplicationTest as upstreamSetupApplicationTest,
@@ -6,6 +5,8 @@ import {
   setupTest as upstreamSetupTest,
 } from 'ember-qunit';
 import type Resolver from 'ember-resolver';
+
+import { takeSnapshot } from './percy';
 
 interface SetupTestOptions {
   resolver?: Resolver | undefined;
@@ -48,8 +49,8 @@ function setupTest(hooks: NestedHooks, options?: SetupTestOptions) {
 
 export {
   a11yAudit,
-  percySnapshot,
   setupApplicationTest,
   setupRenderingTest,
   setupTest,
+  takeSnapshot,
 };

--- a/docs/embroider-css-modules/tests/helpers/percy.ts
+++ b/docs/embroider-css-modules/tests/helpers/percy.ts
@@ -1,0 +1,26 @@
+import percySnapshot from '@percy/ember';
+
+type QUnitAssert = {
+  test: {
+    module: {
+      name: string;
+    };
+    testName: string;
+  };
+};
+
+function getName(qunitAssert: QUnitAssert): string {
+  const packageName = 'docs-app-for-embroider-css-modules';
+  const moduleName = qunitAssert.test.module.name;
+  const testName = qunitAssert.test.testName;
+
+  const name = `${moduleName} | ${testName} (${packageName})`;
+
+  return name;
+}
+
+export async function takeSnapshot(qunitAssert: unknown): Promise<void> {
+  const name = getName(qunitAssert as QUnitAssert);
+
+  await percySnapshot(name);
+}


### PR DESCRIPTION
## Background

In #82, I had installed Percy in `docs-app-for-embroider-css-modules-temporary`. I let both docs-apps use the same Percy token so that I can review all snapshots from one place.

I didn't realize Percy would flag some snapshots in #84, because both apps happen to have a test named `Acceptance | index | Visual regression`.


## Solution

To break the tie, I suffixed the usual name by the package name.

In addition, I created a wrapper called `takeSnapshot` so that each test doesn't need to provide the package name. (The wrapper approach can be considered stable, as it comes from [`ember-container-query`](https://github.com/ijlee2/ember-container-query/blob/4.0.4/docs-app/tests/helpers/percy.ts#L69-L89).)
