### PR TITLE
Downstreamed bug fix from @embroider/addon-blueprint#155

### DIFF
--- a/docs/sample-v2-addon/package.json
+++ b/docs/sample-v2-addon/package.json
@@ -82,7 +82,6 @@
     "@glint/environment-ember-template-imports": "^1.0.2",
     "@glint/template": "^1.0.2",
     "@rollup/plugin-babel": "^6.0.3",
-    "@rollup/plugin-node-resolve": "^15.1.0",
     "@shared-configs/ember-template-lint": "workspace:*",
     "@shared-configs/eslint-config-ember": "workspace:*",
     "@shared-configs/prettier": "workspace:*",

--- a/docs/sample-v2-addon/rollup.config.mjs
+++ b/docs/sample-v2-addon/rollup.config.mjs
@@ -1,6 +1,5 @@
 import { Addon } from '@embroider/addon-dev/rollup';
 import { babel } from '@rollup/plugin-babel';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 import postcss from 'rollup-plugin-postcss';
 
 const addon = new Addon({
@@ -52,11 +51,6 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions,
-    }),
-
-    // Allows rollup to resolve imports of files with the specified extensions
-    nodeResolve({
       extensions,
     }),
 

--- a/docs/sample-v2-addon/src/components/ui/page.ts
+++ b/docs/sample-v2-addon/src/components/ui/page.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 import { WithBoundArgs } from '@glint/template';
 
 import styles from './page.css';
-import type UiPageDemoComponent from './page/demo';
-import type UiPageSectionComponent from './page/section';
-import type UiPageSubsectionComponent from './page/subsection';
+import type UiPageDemoComponent from './page/demo.ts';
+import type UiPageSectionComponent from './page/section.ts';
+import type UiPageSubsectionComponent from './page/subsection.ts';
 
 interface UiPageSignature {
   Args: {

--- a/docs/sample-v2-addon/src/index.ts
+++ b/docs/sample-v2-addon/src/index.ts
@@ -1,2 +1,2 @@
-export { default as NavigationMenu } from './components/navigation-menu';
-export { default as UiPage } from './components/ui/page';
+export { default as NavigationMenu } from './components/navigation-menu.ts';
+export { default as UiPage } from './components/ui/page.ts';

--- a/docs/sample-v2-addon/src/template-registry.ts
+++ b/docs/sample-v2-addon/src/template-registry.ts
@@ -1,8 +1,8 @@
-import type NavigationMenuComponent from './components/navigation-menu';
-import type UiPageComponent from './components/ui/page';
-import type UiPageDemoComponent from './components/ui/page/demo';
-import type UiPageSectionComponent from './components/ui/page/section';
-import type UiPageSubsectionComponent from './components/ui/page/subsection';
+import type NavigationMenuComponent from './components/navigation-menu.ts';
+import type UiPageComponent from './components/ui/page.ts';
+import type UiPageDemoComponent from './components/ui/page/demo.ts';
+import type UiPageSectionComponent from './components/ui/page/section.ts';
+import type UiPageSubsectionComponent from './components/ui/page/subsection.ts';
 
 export default interface SampleV2AddonRegistry {
   NavigationMenu: typeof NavigationMenuComponent;

--- a/docs/sample-v2-addon/tsconfig.json
+++ b/docs/sample-v2-addon/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@shared-configs/typescript/ember",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/docs/sample-v2-addon/unpublished-development-types/index.d.ts
+++ b/docs/sample-v2-addon/unpublished-development-types/index.d.ts
@@ -6,7 +6,7 @@ import '@glint/environment-ember-template-imports';
 
 import type EmbroiderCssModulesRegistry from 'embroider-css-modules/template-registry';
 
-import SampleV2AddonRegistry from '../src/template-registry';
+import type SampleV2AddonRegistry from '../src/template-registry.ts';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry

--- a/docs/written-guides/set-up-css-modules-v2-addons.md
+++ b/docs/written-guides/set-up-css-modules-v2-addons.md
@@ -21,7 +21,6 @@ A "standard" v2 addon, created with [`@embroider/addon-blueprint`](https://githu
 
 - `rollup`
 - `@rollup/plugin-babel`
-- `@rollup/plugin-node-resolve`
 
 For PostCSS, here is what you likely need at minimum.
 
@@ -58,7 +57,6 @@ For simplicity, the comments have been hidden.
 ```js
 import { Addon } from '@embroider/addon-dev/rollup';
 import { babel } from '@rollup/plugin-babel';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 import copy from 'rollup-plugin-copy';
 
 const addon = new Addon({
@@ -84,10 +82,6 @@ export default {
 
     babel({
       babelHelpers: 'bundled',
-      extensions,
-    }),
-
-    nodeResolve({
       extensions,
     }),
 
@@ -121,7 +115,6 @@ Add `rollup-plugin-postcss` before `babel()` (order matters). Then, remove the g
 ```diff
 import { Addon } from '@embroider/addon-dev/rollup';
 import { babel } from '@rollup/plugin-babel';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 import copy from 'rollup-plugin-copy';
 + import postcss from 'rollup-plugin-postcss';
 
@@ -155,10 +148,6 @@ export default {
 +
     babel({
       babelHelpers: 'bundled',
-      extensions,
-    }),
-
-    nodeResolve({
       extensions,
     }),
 

--- a/packages/embroider-css-modules-temporary/package.json
+++ b/packages/embroider-css-modules-temporary/package.json
@@ -75,7 +75,6 @@
     "@glint/environment-ember-loose": "^1.0.2",
     "@glint/template": "^1.0.2",
     "@rollup/plugin-babel": "^6.0.3",
-    "@rollup/plugin-node-resolve": "^15.1.0",
     "@shared-configs/ember-template-lint": "workspace:*",
     "@shared-configs/eslint-config-ember": "workspace:*",
     "@shared-configs/prettier": "workspace:*",

--- a/packages/embroider-css-modules-temporary/rollup.config.mjs
+++ b/packages/embroider-css-modules-temporary/rollup.config.mjs
@@ -1,6 +1,5 @@
 import { Addon } from '@embroider/addon-dev/rollup';
 import { babel } from '@rollup/plugin-babel';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 const addon = new Addon({
   srcDir: 'src',
@@ -42,11 +41,6 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions,
-    }),
-
-    // Allows rollup to resolve imports of files with the specified extensions
-    nodeResolve({
       extensions,
     }),
 

--- a/packages/embroider-css-modules-temporary/src/index.ts
+++ b/packages/embroider-css-modules-temporary/src/index.ts
@@ -1,1 +1,1 @@
-export { default as localClassNew } from './helpers/local-class-new';
+export { default as localClassNew } from './helpers/local-class-new.ts';

--- a/packages/embroider-css-modules-temporary/src/template-registry.ts
+++ b/packages/embroider-css-modules-temporary/src/template-registry.ts
@@ -1,4 +1,4 @@
-import type LocalClassNewHelper from './helpers/local-class-new';
+import type LocalClassNewHelper from './helpers/local-class-new.ts';
 
 export default interface EmbroiderCssModulesTemporaryRegistry {
   'local-class-new': typeof LocalClassNewHelper;

--- a/packages/embroider-css-modules-temporary/tsconfig.json
+++ b/packages/embroider-css-modules-temporary/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@shared-configs/typescript/ember",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/packages/embroider-css-modules-temporary/unpublished-development-types/index.d.ts
+++ b/packages/embroider-css-modules-temporary/unpublished-development-types/index.d.ts
@@ -3,7 +3,7 @@
 
 import '@glint/environment-ember-loose';
 
-import EmbroiderCssModulesTemporaryRegistry from '../src/template-registry';
+import type EmbroiderCssModulesTemporaryRegistry from '../src/template-registry.ts';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry

--- a/packages/embroider-css-modules/package.json
+++ b/packages/embroider-css-modules/package.json
@@ -75,7 +75,6 @@
     "@glint/environment-ember-loose": "^1.0.2",
     "@glint/template": "^1.0.2",
     "@rollup/plugin-babel": "^6.0.3",
-    "@rollup/plugin-node-resolve": "^15.1.0",
     "@shared-configs/ember-template-lint": "workspace:*",
     "@shared-configs/eslint-config-ember": "workspace:*",
     "@shared-configs/prettier": "workspace:*",

--- a/packages/embroider-css-modules/rollup.config.mjs
+++ b/packages/embroider-css-modules/rollup.config.mjs
@@ -1,6 +1,5 @@
 import { Addon } from '@embroider/addon-dev/rollup';
 import { babel } from '@rollup/plugin-babel';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 const addon = new Addon({
   srcDir: 'src',
@@ -42,11 +41,6 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions,
-    }),
-
-    // Allows rollup to resolve imports of files with the specified extensions
-    nodeResolve({
       extensions,
     }),
 

--- a/packages/embroider-css-modules/src/index.ts
+++ b/packages/embroider-css-modules/src/index.ts
@@ -1,1 +1,1 @@
-export { default as localClass } from './helpers/local-class';
+export { default as localClass } from './helpers/local-class.ts';

--- a/packages/embroider-css-modules/src/template-registry.ts
+++ b/packages/embroider-css-modules/src/template-registry.ts
@@ -1,4 +1,4 @@
-import type LocalClassHelper from './helpers/local-class';
+import type LocalClassHelper from './helpers/local-class.ts';
 
 export default interface EmbroiderCssModulesRegistry {
   'local-class': typeof LocalClassHelper;

--- a/packages/embroider-css-modules/tsconfig.json
+++ b/packages/embroider-css-modules/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@shared-configs/typescript/ember",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/packages/embroider-css-modules/unpublished-development-types/index.d.ts
+++ b/packages/embroider-css-modules/unpublished-development-types/index.d.ts
@@ -3,7 +3,7 @@
 
 import '@glint/environment-ember-loose';
 
-import EmbroiderCssModulesRegistry from '../src/template-registry';
+import type EmbroiderCssModulesRegistry from '../src/template-registry.ts';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry extends EmbroiderCssModulesRegistry {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,9 +646,6 @@ importers:
       '@rollup/plugin-babel':
         specifier: ^6.0.3
         version: 6.0.3(@babel/core@7.22.5)(rollup@3.25.1)
-      '@rollup/plugin-node-resolve':
-        specifier: ^15.1.0
-        version: 15.1.0(rollup@3.25.1)
       '@shared-configs/ember-template-lint':
         specifier: workspace:*
         version: link:../../configs/ember-template-lint
@@ -789,9 +786,6 @@ importers:
       '@rollup/plugin-babel':
         specifier: ^6.0.3
         version: 6.0.3(@babel/core@7.22.5)(rollup@3.25.1)
-      '@rollup/plugin-node-resolve':
-        specifier: ^15.1.0
-        version: 15.1.0(rollup@3.25.1)
       '@shared-configs/ember-template-lint':
         specifier: workspace:*
         version: link:../../configs/ember-template-lint
@@ -865,9 +859,6 @@ importers:
       '@rollup/plugin-babel':
         specifier: ^6.0.3
         version: 6.0.3(@babel/core@7.22.5)(rollup@3.25.1)
-      '@rollup/plugin-node-resolve':
-        specifier: ^15.1.0
-        version: 15.1.0(rollup@3.25.1)
       '@shared-configs/ember-template-lint':
         specifier: workspace:*
         version: link:../../configs/ember-template-lint
@@ -4682,24 +4673,6 @@ packages:
       rollup: 3.25.1
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.25.1):
-    resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.78.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-builtin-module: 3.2.1
-      is-module: 1.0.0
-      resolve: 1.22.2
-      rollup: 3.25.1
-    dev: true
-
   /@rollup/pluginutils@4.2.1:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
@@ -5132,10 +5105,6 @@ packages:
 
   /@types/range-parser@1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
-    dev: true
-
-  /@types/resolve@1.20.2:
-    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
   /@types/responselike@1.0.0:
@@ -7322,11 +7291,6 @@ packages:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  /builtin-modules@3.3.0:
-    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
-    engines: {node: '>=6'}
-    dev: true
-
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
@@ -8539,11 +8503,6 @@ packages:
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  /deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
-    dev: true
 
   /default-browser-id@3.0.0:
     resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
@@ -11912,13 +11871,6 @@ packages:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
     dev: true
 
-  /is-builtin-module@3.2.1:
-    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
-    engines: {node: '>=6'}
-    dependencies:
-      builtin-modules: 3.3.0
-    dev: true
-
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -12048,10 +12000,6 @@ packages:
   /is-map@2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
     dev: false
-
-  /is-module@1.0.0:
-    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
-    dev: true
 
   /is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}


### PR DESCRIPTION
## Description

In [`@embroider/addon-blueprint@2.0.0`](https://github.com/embroider-build/addon-blueprint/releases/tag/v2.0.0) and [`2.1.0`](https://github.com/embroider-build/addon-blueprint/releases/tag/v2.1.0), end-developers are expected to (1) _not_ use `@rollup/plugin-node-resolve` and (2) add the file extension `.ts` when using relative imports.


## References

- https://github.com/ijlee2/ember-codemod-v1-to-v2/pull/57