### PR TITLE
Updated CI to run on Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 18
   PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_number }}
   PERCY_PARALLEL_TOTAL: 2
 
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2
@@ -71,7 +71,7 @@ jobs:
       RUN_PERCY: ${{ matrix.package-location == 'docs/embroider-css-modules' || matrix.package-location == 'docs/embroider-css-modules-temporary' }}
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2
@@ -120,7 +120,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2
@@ -159,7 +159,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
## Background

Node 16 LTS is no longer supported as of September 11, 2023. Node 18 LTS will be supported until April 30, 2025.


## What changed?

Rather than dropping Node 18 support for all packages at once, I will do so in increments. For the first step, I updated the CI workflow to run on Node 18.
