### PR TITLE
Enabled embroider-safe and embroider-optimized (test-for-my-v2-addon)

### DIFF
--- a/.changeset/great-pants-fold.md
+++ b/.changeset/great-pants-fold.md
@@ -1,0 +1,6 @@
+---
+"my-v2-addon": patch
+"test-app-for-my-v2-addon": patch
+---
+
+Enabled embroider-safe and embroider-optimized in CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,8 @@ jobs:
           - 'ember-release'
           - 'ember-beta'
           - 'ember-canary'
-          # - 'embroider-safe'
-          # - 'embroider-optimized'
+          - 'embroider-safe'
+          - 'embroider-optimized'
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo


### PR DESCRIPTION
## Description

In #29, the two scenarios had been disabled after CI failed, but I don't recall why. The CI logs aren't available anymore.

<img width="900" alt="" src="https://github.com/ijlee2/embroider-css-modules/assets/16869656/0a3211aa-8463-4d27-a287-8dd448fa5ba7">

At any rate, the scenarios are passing now, so let's keep them enabled.
