### PR TITLE
Updated release:publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "pnpm --filter '*' lint:fix",
     "prepare": "pnpm --filter './packages/**' --filter my-v2-addon build",
     "release:changelog": "changeset version",
-    "release:publish": "changeset publish",
+    "release:publish": "pnpm build && changeset publish",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:embroider-css-modules": "pnpm --filter embroider-css-modules start",
     "start:my-app": "pnpm --filter my-app start",


### PR DESCRIPTION
## Description

I found out that, if `pnpm build && pnpm publish` is run, then the `prepare` script is run before `publish`. As a result, packages are built 2 times when `release:publish` is called.

On the other hand, if `pnpm build && changeset publish` is run, then the `prepare` script does not run before `publish`. As a result, maintainers must take caution and ensure that the latest code will be published.

To mitigate a possible error, I updated `release:publish` to run the `build` script.
