### PR TITLE
Temporarily allowed ember-canary to fail

### DIFF
--- a/tests/embroider-css-modules/config/ember-try.js
+++ b/tests/embroider-css-modules/config/ember-try.js
@@ -49,6 +49,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-canary',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),

--- a/tests/my-v2-addon/config/ember-try.js
+++ b/tests/my-v2-addon/config/ember-try.js
@@ -49,6 +49,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-canary',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),


### PR DESCRIPTION
## Description

While working on #117, I noticed that tests written in `.gts` format would fail in the `ember-canary` scenario (with `ember-source@5.6.0-alpha.1`).

As the failure is likely be caused upstream by `ember-source` or `@embroider/*`, I'll temporarily allow the scenario to fail. An alternative is to skip the `.gts` tests.
