### PR TITLE
Downstreamed changes from @embroider/addon-blueprint@2.11.0

### DIFF
--- a/.changeset/beige-timers-roll.md
+++ b/.changeset/beige-timers-roll.md
@@ -1,0 +1,7 @@
+---
+"embroider-css-modules": patch
+"my-v1-addon": patch
+"my-app": patch
+---
+
+Downstreamed changes from @embroider/addon-blueprint@2.11.0

--- a/docs/my-app/ember-cli-build.js
+++ b/docs/my-app/ember-cli-build.js
@@ -30,10 +30,6 @@ module.exports = function (defaults) {
             ? '[sha512:hash:base64:5]'
             : '[path][name]__[local]',
           mode: (resourcePath) => {
-            // The host app and active child addons are moved into a shared
-            // temporary directory (`options.workspaceDir`) before css-loader
-            // processes them.
-            //
             // We want to enable the local mode only for our own host app.
             // All other addons should be loaded in the global mode.
             const hostAppLocation =

--- a/docs/my-v1-addon/types/dummy/index.d.ts
+++ b/docs/my-v1-addon/types/dummy/index.d.ts
@@ -1,4 +1,5 @@
 import '@glint/environment-ember-loose';
+import '@glint/environment-ember-template-imports';
 import 'ember-source/types';
 import 'ember-source/types/preview';
 

--- a/packages/embroider-css-modules/babel.config.json
+++ b/packages/embroider-css-modules/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/packages/embroider-css-modules/package.json
+++ b/packages/embroider-css-modules/package.json
@@ -62,13 +62,11 @@
     "test": "echo 'A v2 addon does not have tests, run tests in tests/embroider-css-modules'"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.7"
+    "@embroider/addon-shim": "^1.8.7",
+    "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.6",
-    "@babel/plugin-proposal-decorators": "^7.23.6",
-    "@babel/plugin-transform-class-properties": "^7.23.3",
-    "@babel/plugin-transform-class-static-block": "^7.23.4",
     "@babel/plugin-transform-typescript": "^7.23.6",
     "@babel/runtime": "^7.23.6",
     "@embroider/addon-dev": "^4.1.3",

--- a/packages/embroider-css-modules/package.json
+++ b/packages/embroider-css-modules/package.json
@@ -72,6 +72,7 @@
     "@embroider/addon-dev": "^4.1.3",
     "@glint/core": "^1.2.1",
     "@glint/environment-ember-loose": "^1.2.1",
+    "@glint/environment-ember-template-imports": "^1.2.1",
     "@glint/template": "^1.2.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@shared-configs/ember-template-lint": "workspace:*",

--- a/packages/embroider-css-modules/tsconfig.json
+++ b/packages/embroider-css-modules/tsconfig.json
@@ -4,6 +4,7 @@
     "allowImportingTsExtensions": true,
     "allowJs": true,
     "declarationDir": "declarations",
+    "rootDir": "./src",
     "skipLibCheck": true
   },
   "include": [

--- a/packages/embroider-css-modules/unpublished-development-types/index.d.ts
+++ b/packages/embroider-css-modules/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 
 import '@glint/environment-ember-loose';
+import '@glint/environment-ember-template-imports';
 
 import type EmbroiderCssModulesRegistry from '../src/template-registry.ts';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -934,19 +934,13 @@ importers:
       '@embroider/addon-shim':
         specifier: ^1.8.7
         version: 1.8.7
+      decorator-transforms:
+        specifier: ^1.0.1
+        version: 1.0.1(@babel/core@7.23.6)
     devDependencies:
       '@babel/core':
         specifier: ^7.23.6
         version: 7.23.6(supports-color@8.1.1)
-      '@babel/plugin-proposal-decorators':
-        specifier: ^7.23.6
-        version: 7.23.6(@babel/core@7.23.6)
-      '@babel/plugin-transform-class-properties':
-        specifier: ^7.23.3
-        version: 7.23.3(@babel/core@7.23.6)
-      '@babel/plugin-transform-class-static-block':
-        specifier: ^7.23.4
-        version: 7.23.4(@babel/core@7.23.6)
       '@babel/plugin-transform-typescript':
         specifier: ^7.23.6
         version: 7.23.6(@babel/core@7.23.6)
@@ -962,6 +956,9 @@ importers:
       '@glint/environment-ember-loose':
         specifier: ^1.2.1
         version: 1.2.1(@glimmer/component@1.1.2)(@glint/template@1.2.1)(@types/ember__component@4.0.21)
+      '@glint/environment-ember-template-imports':
+        specifier: ^1.2.1
+        version: 1.2.1(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(@types/ember__component@4.0.21)(ember-template-imports@3.4.2)
       '@glint/template':
         specifier: ^1.2.1
         version: 1.2.1
@@ -3602,6 +3599,32 @@ packages:
       '@glint/template': 1.2.1
       ember-cli-htmlbars: 6.3.0
       ember-modifier: 4.1.0(ember-source@5.5.0)
+
+  /@glint/environment-ember-template-imports@1.2.1(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(@types/ember__component@4.0.21)(ember-template-imports@3.4.2):
+    resolution: {integrity: sha512-yTuF8oQyvVKmU3fCuYtg8Gf02VghQYI36x5/eob6yaMx2M+p3MFO+E6X7ANz/1bYRXphEPTWQMgdDjM4C6Ql4A==}
+    peerDependencies:
+      '@glint/environment-ember-loose': ^1.2.1
+      '@glint/template': ^1.2.1
+      '@types/ember__component': ^4.0.10
+      '@types/ember__helper': ^4.0.1
+      '@types/ember__modifier': ^4.0.3
+      '@types/ember__routing': ^4.0.12
+      ember-template-imports: ^3.0.0
+    peerDependenciesMeta:
+      '@types/ember__component':
+        optional: true
+      '@types/ember__helper':
+        optional: true
+      '@types/ember__modifier':
+        optional: true
+      '@types/ember__routing':
+        optional: true
+    dependencies:
+      '@glint/environment-ember-loose': 1.2.1(@glimmer/component@1.1.2)(@glint/template@1.2.1)(@types/ember__component@4.0.21)
+      '@glint/template': 1.2.1
+      '@types/ember__component': 4.0.21(@babel/core@7.23.6)
+      ember-template-imports: 3.4.2
+    dev: true
 
   /@glint/environment-ember-template-imports@1.2.1(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(ember-template-imports@3.4.2):
     resolution: {integrity: sha512-yTuF8oQyvVKmU3fCuYtg8Gf02VghQYI36x5/eob6yaMx2M+p3MFO+E6X7ANz/1bYRXphEPTWQMgdDjM4C6Ql4A==}
@@ -7926,6 +7949,15 @@ packages:
     dependencies:
       mimic-response: 1.0.1
     dev: true
+
+  /decorator-transforms@1.0.1(@babel/core@7.23.6):
+    resolution: {integrity: sha512-ZOaiw4tqiyhtqiMKCNzjS+nGsYPZltToqRAFc5rOUcc4u8d7MTlgelw1qXfL6ieg2l6xZcz6lTZ5M94Ohnk2xA==}
+    dependencies:
+      '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.23.6)
+      babel-import-util: 2.0.1
+    transitivePeerDependencies:
+      - '@babel/core'
+    dev: false
 
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}


### PR DESCRIPTION
## Description

By replacing a few Babel plugins with [`decorator-transforms`](https://github.com/ef4/decorator-transforms), we can ship fewer bytes and avoid the need to transpile other class features.

| | Before | After |
|--:|:--:|:--:|
| Package size | 5.6 kB | 5.6 kB |
| Unpacked size | 15.1 kB | 15.0 kB |
| Total files | 17 | 17 |

Note, unlike in [`ember-container-query`](https://github.com/ijlee2/ember-container-query/pull/217), the size reduction is minimal. This may be because `embroider-css-modules` currently provides just 1 helper.
