### PR TITLE
Introduced @embroider/broccoli-side-watch for live reload in apps

### DIFF
--- a/.changeset/popular-radios-juggle.md
+++ b/.changeset/popular-radios-juggle.md
@@ -1,0 +1,8 @@
+---
+"my-app-with-ember-css-modules": patch
+"test-app-for-embroider-css-modules": patch
+"test-app-for-my-v2-addon": patch
+"my-app": patch
+---
+
+Introduced @embroider/broccoli-side-watch for live reload in apps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: latest
 
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: latest
 
@@ -124,7 +124,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: latest
 
@@ -164,7 +164,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: latest
 
@@ -204,7 +204,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: latest
 

--- a/docs/my-app-with-ember-css-modules/ember-cli-build.js
+++ b/docs/my-app-with-ember-css-modules/ember-cli-build.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const sideWatch = require('@embroider/broccoli-side-watch');
 const { Webpack } = require('@embroider/webpack');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
@@ -7,10 +8,23 @@ module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     // Add options here
     autoImport: {
-      watchDependencies: ['embroider-css-modules', 'my-v2-addon'],
+      watchDependencies: [
+        // 'embroider-css-modules',
+        // 'my-v2-addon',
+      ],
     },
+
     'ember-cli-babel': {
       enableTypeScriptTransform: true,
+    },
+
+    trees: {
+      app: sideWatch('app', {
+        watching: [
+          '../../packages/embroider-css-modules/src',
+          '../my-v2-addon/src',
+        ],
+      }),
     },
   });
 

--- a/docs/my-app-with-ember-css-modules/package.json
+++ b/docs/my-app-with-ember-css-modules/package.json
@@ -42,6 +42,7 @@
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.0",
+    "@embroider/broccoli-side-watch": "0.0.2-unstable.ba9fd29",
     "@embroider/compat": "^3.4.4",
     "@embroider/core": "^3.4.4",
     "@embroider/router": "^2.1.6",

--- a/docs/my-app/ember-cli-build.js
+++ b/docs/my-app/ember-cli-build.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const sideWatch = require('@embroider/broccoli-side-watch');
 const { Webpack } = require('@embroider/webpack');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
@@ -12,13 +13,22 @@ module.exports = function (defaults) {
     // Add options here
     autoImport: {
       watchDependencies: [
-        'embroider-css-modules',
-        'my-v1-addon',
-        'my-v2-addon',
+        // 'embroider-css-modules',
+        // 'my-v2-addon',
       ],
     },
+
     'ember-cli-babel': {
       enableTypeScriptTransform: true,
+    },
+
+    trees: {
+      app: sideWatch('app', {
+        watching: [
+          '../../packages/embroider-css-modules/src',
+          '../my-v2-addon/src',
+        ],
+      }),
     },
   });
 

--- a/docs/my-app/package.json
+++ b/docs/my-app/package.json
@@ -42,6 +42,7 @@
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.0",
+    "@embroider/broccoli-side-watch": "0.0.2-unstable.ba9fd29",
     "@embroider/compat": "^3.4.4",
     "@embroider/core": "^3.4.4",
     "@embroider/macros": "^1.13.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       '@ember/test-helpers':
         specifier: ^3.3.0
         version: 3.3.0(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.3)
+      '@embroider/broccoli-side-watch':
+        specifier: 0.0.2-unstable.ba9fd29
+        version: 0.0.2-unstable.ba9fd29
       '@embroider/compat':
         specifier: ^3.4.4
         version: 3.4.4(@embroider/core@3.4.4)(@glint/template@1.3.0)
@@ -448,6 +451,9 @@ importers:
       '@ember/test-helpers':
         specifier: ^3.3.0
         version: 3.3.0(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.3)
+      '@embroider/broccoli-side-watch':
+        specifier: 0.0.2-unstable.ba9fd29
+        version: 0.0.2-unstable.ba9fd29
       '@embroider/compat':
         specifier: ^3.4.4
         version: 3.4.4(@embroider/core@3.4.4)(@glint/template@1.3.0)
@@ -1056,6 +1062,9 @@ importers:
       '@ember/test-helpers':
         specifier: ^3.3.0
         version: 3.3.0(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.3)
+      '@embroider/broccoli-side-watch':
+        specifier: 0.0.2-unstable.ba9fd29
+        version: 0.0.2-unstable.ba9fd29
       '@embroider/test-setup':
         specifier: ^3.0.3
         version: 3.0.3
@@ -1203,6 +1212,9 @@ importers:
       '@ember/test-helpers':
         specifier: ^3.3.0
         version: 3.3.0(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.3)
+      '@embroider/broccoli-side-watch':
+        specifier: 0.0.2-unstable.ba9fd29
+        version: 0.0.2-unstable.ba9fd29
       '@embroider/test-setup':
         specifier: ^3.0.3
         version: 3.0.3
@@ -2964,6 +2976,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - webpack
+    dev: true
+
+  /@embroider/broccoli-side-watch@0.0.2-unstable.ba9fd29:
+    resolution: {integrity: sha512-jxMe47Rc2fUAwtKGsPy9x7gtYJpglTlbeRG5bgzs8njYZHbOiXRyhpNMcfJnn7f6Aoc4Xv4qXvTHeyye/6SyZw==}
+    dependencies:
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@embroider/compat@3.4.4(@embroider/core@3.4.4)(@glint/template@1.3.0):

--- a/tests/embroider-css-modules/ember-cli-build.js
+++ b/tests/embroider-css-modules/ember-cli-build.js
@@ -1,15 +1,25 @@
 'use strict';
 
+const sideWatch = require('@embroider/broccoli-side-watch');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     // Add options here
     autoImport: {
-      watchDependencies: ['embroider-css-modules'],
+      watchDependencies: [
+        // 'embroider-css-modules',
+      ],
     },
+
     'ember-cli-babel': {
       enableTypeScriptTransform: true,
+    },
+
+    trees: {
+      app: sideWatch('app', {
+        watching: ['../../packages/embroider-css-modules/src'],
+      }),
     },
   });
 

--- a/tests/embroider-css-modules/package.json
+++ b/tests/embroider-css-modules/package.json
@@ -41,6 +41,7 @@
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.0",
+    "@embroider/broccoli-side-watch": "0.0.2-unstable.ba9fd29",
     "@embroider/test-setup": "^3.0.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/tests/my-v2-addon/ember-cli-build.js
+++ b/tests/my-v2-addon/ember-cli-build.js
@@ -1,15 +1,25 @@
 'use strict';
 
+const sideWatch = require('@embroider/broccoli-side-watch');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     // Add options here
     autoImport: {
-      watchDependencies: ['my-v2-addon'],
+      watchDependencies: [
+        // 'my-v2-addon',
+      ],
     },
+
     'ember-cli-babel': {
       enableTypeScriptTransform: true,
+    },
+
+    trees: {
+      app: sideWatch('app', {
+        watching: ['../../docs/my-v2-addon/src'],
+      }),
     },
   });
 

--- a/tests/my-v2-addon/package.json
+++ b/tests/my-v2-addon/package.json
@@ -40,6 +40,7 @@
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.0",
+    "@embroider/broccoli-side-watch": "0.0.2-unstable.ba9fd29",
     "@embroider/test-setup": "^3.0.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",


### PR DESCRIPTION
## Description

To ease development, I installed [`@embroider/broccoli-side-watch`](https://github.com/embroider-build/embroider/tree/main/packages/broccoli-side-watch) to look for file changes.

I tested that the apps in `docs` and `tests` folders are rebuilt when a file in `embroider-css-modules` or `my-v2-addon` is updated.
