### PR TITLE
Fixed lint errors

### DIFF
--- a/.changeset/ninety-turkeys-hear.md
+++ b/.changeset/ninety-turkeys-hear.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-remove-ember-css-modules": minor
+---
+
+Fixed lint errors

--- a/packages/ember-codemod-remove-ember-css-modules/src/utils/steps/import-styles/update-class.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/src/utils/steps/import-styles/update-class.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -34,6 +33,7 @@ function removeTemplateOnlyComponentMethod(file: string, data: Data): string {
 
   const ast = traverse(file, {
     visitCallExpression(path) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (path.value.callee.name !== 'templateOnlyComponent') {
         return false;
       }
@@ -41,6 +41,7 @@ function removeTemplateOnlyComponentMethod(file: string, data: Data): string {
       const superClass = AST.builders.identifier('Component');
 
       if (data.isTypeScript) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         superClass.typeAnnotation = path.value.typeParameters;
       }
 
@@ -57,15 +58,18 @@ function removeTemplateOnlyComponentMethod(file: string, data: Data): string {
     },
 
     visitImportDeclaration(path) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (path.value.source.value !== '@ember/component/template-only') {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       const defaultImport = path.value.specifiers.find(
         (specifier: { type: string }) =>
           specifier.type === 'ImportDefaultSpecifier',
       );
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (defaultImport?.local?.name !== 'templateOnlyComponent') {
         return false;
       }
@@ -95,6 +99,7 @@ function importStylesInClass(file: string, data: Data): string {
       if (!lastImportDeclarationPath) {
         lastImportDeclarationPath = path;
         // @ts-expect-error: Incorrect type
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       } else if (path.node.start > lastImportDeclarationPath.node.start) {
         lastImportDeclarationPath = path;
       }
@@ -105,10 +110,13 @@ function importStylesInClass(file: string, data: Data): string {
 
   // Append the styles import
   // @ts-expect-error: Incorrect type
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
   const nodes = ast.program.body;
   // @ts-expect-error: Incorrect type
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const index = lastImportDeclarationPath?.name ?? -1;
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
   nodes.splice(
     index + 1,
     0,

--- a/packages/ember-codemod-remove-ember-css-modules/src/utils/steps/import-styles/update-class.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/src/utils/steps/import-styles/update-class.ts
@@ -33,16 +33,17 @@ function removeTemplateOnlyComponentMethod(file: string, data: Data): string {
 
   const ast = traverse(file, {
     visitCallExpression(path) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (path.value.callee.name !== 'templateOnlyComponent') {
+      // @ts-expect-error: Incorrect type
+      if (path.node.callee.name !== 'templateOnlyComponent') {
         return false;
       }
 
       const superClass = AST.builders.identifier('Component');
 
       if (data.isTypeScript) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        superClass.typeAnnotation = path.value.typeParameters;
+        // @ts-expect-error: Incorrect type
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        superClass.typeAnnotation = path.node.typeParameters;
       }
 
       return AST.builders.classExpression(
@@ -58,18 +59,15 @@ function removeTemplateOnlyComponentMethod(file: string, data: Data): string {
     },
 
     visitImportDeclaration(path) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (path.value.source.value !== '@ember/component/template-only') {
+      if (path.node.source.value !== '@ember/component/template-only') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      const defaultImport = path.value.specifiers.find(
+      const defaultImport = path.node.specifiers?.find(
         (specifier: { type: string }) =>
           specifier.type === 'ImportDefaultSpecifier',
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (defaultImport?.local?.name !== 'templateOnlyComponent') {
         return false;
       }

--- a/packages/ember-codemod-remove-ember-css-modules/src/utils/steps/update-templates/update-template.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/src/utils/steps/update-templates/update-template.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -30,11 +29,13 @@ function sanitizeClassAndLocalClassAttributes(file: string): string {
     }
 
     // @ts-expect-error: Incorrect type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (attribute.value.type !== 'TextNode') {
       return;
     }
 
     // @ts-expect-error: Incorrect type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const attributeValue = attribute.value.chars.trim();
 
     if (attributeValue === '') {
@@ -128,28 +129,34 @@ function removeLocalClassHelpers(file: string): string {
     1 positional argument. The argument's value is presumed
     to be a concatenated string or `undefined`.
   */
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   function canRemoveLocalClassHelper(path: unknown) {
     // @ts-expect-error: Incorrect type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const hasFromArgument = path.hash.pairs.some((pair) => pair.key === 'from');
 
     if (hasFromArgument) {
       throw new RangeError(
         // @ts-expect-error: Incorrect type
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         `Unable to handle the {{local-class}} helper's \`from\` key. See lines ${path.loc.start.line}-${path.loc.end.line}.`,
       );
     }
 
     // @ts-expect-error: Incorrect type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     const param = path.params[0]!;
 
     if (param === undefined) {
       return true;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (param.type !== 'StringLiteral') {
       return false;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const value = param.value.trim();
 
     return value === '';
@@ -178,16 +185,21 @@ function removeLocalClassHelpers(file: string): string {
       }
 
       // @ts-expect-error: Incorrect type
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const param = node.value.params[0]!;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (param.type !== 'StringLiteral') {
         return;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       const localClassNames = param.value.trim().split(/\s+/);
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (localClassNames.length === 1) {
         node.value = AST.builders.mustache(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           AST.builders.path(`this.styles.${localClassNames[0]!}`),
         );
 
@@ -196,6 +208,7 @@ function removeLocalClassHelpers(file: string): string {
 
       node.value = AST.builders.mustache(AST.builders.path('local'), [
         AST.builders.path('this.styles'),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         ...localClassNames.map(AST.builders.string),
       ]);
     },
@@ -263,19 +276,24 @@ function removeLocalClassHelpers(file: string): string {
 }
 
 function removeLocalClassAttributes(file: string): string {
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   function transformParam(param: unknown) {
     // @ts-expect-error: Incorrect type
     switch (param.type) {
       case 'StringLiteral': {
         // @ts-expect-error: Incorrect type
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         const localClassNames = param.value.trim().split(/\s+/);
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (localClassNames.length === 1) {
           // @ts-expect-error: Incorrect type
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           param.value = localClassNames[0]!;
         } else {
           param = AST.builders.sexpr(
             'array',
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             localClassNames.map(AST.builders.string),
           );
         }
@@ -285,13 +303,16 @@ function removeLocalClassAttributes(file: string): string {
 
       case 'SubExpression': {
         // @ts-expect-error: Incorrect type
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         switch (param.path.original) {
           case 'if':
           case 'unless': {
             // @ts-expect-error: Incorrect type
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             const subparams = param.params.map(transformParam);
 
             // @ts-expect-error: Incorrect type
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
             param = AST.builders.sexpr(param.path.original, subparams);
 
             break;
@@ -306,32 +327,39 @@ function removeLocalClassAttributes(file: string): string {
   }
 
   // @ts-expect-error: Incorrect type
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   function transformPart(part: unknown) {
     // @ts-expect-error: Incorrect type
     switch (part.type) {
       case 'MustacheStatement': {
         // @ts-expect-error: Incorrect type
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         switch (part.path.original) {
           case 'concat': {
+            // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
             function hasPathExpression(params: unknown[]) {
               // @ts-expect-error: Incorrect type
               return params.some((param) => param.type === 'PathExpression');
             }
 
             // @ts-expect-error: Incorrect type
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             if (hasPathExpression(part.params)) {
               return AST.builders.mustache(AST.builders.path('get'), [
                 AST.builders.path('this.styles'),
                 // @ts-expect-error: Incorrect type
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
                 AST.builders.sexpr(part.path.original, part.params),
               ]);
             }
 
             // @ts-expect-error: Incorrect type
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             const params = part.params.map(transformParam);
 
             return AST.builders.mustache('local', [
               AST.builders.path('this.styles'),
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               ...params,
             ]);
           }
@@ -339,11 +367,13 @@ function removeLocalClassAttributes(file: string): string {
           case 'if':
           case 'unless': {
             // @ts-expect-error: Incorrect type
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             const params = part.params.map(transformParam);
 
             return AST.builders.mustache('local', [
               AST.builders.path('this.styles'),
               // @ts-expect-error: Incorrect type
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
               AST.builders.sexpr(part.path.original, params),
             ]);
           }
@@ -360,37 +390,45 @@ function removeLocalClassAttributes(file: string): string {
 
       case 'TextNode': {
         // @ts-expect-error: Incorrect type
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         const value = part.chars.trim();
 
         if (value === '') {
           return part;
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         const localClassNames = value.split(/\s+/);
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (localClassNames.length === 1) {
           return AST.builders.mustache(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             AST.builders.path(`this.styles.${localClassNames[0]!}`),
           );
         }
 
         return AST.builders.mustache(AST.builders.path('local'), [
           AST.builders.path('this.styles'),
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           ...localClassNames.map(AST.builders.string),
         ]);
       }
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   function transformParts(parts: unknown[]) {
     const numParts = parts.length;
 
     return parts.reduce((accumulator, part, index) => {
       // @ts-expect-error: Incorrect type
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       accumulator.push(transformPart(part));
 
       if (index < numParts - 1) {
         // @ts-expect-error: Incorrect type
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         accumulator.push(AST.builders.text(' '));
       }
 

--- a/packages/ember-codemod-remove-ember-css-modules/src/utils/steps/update-templates/update-template.ts
+++ b/packages/ember-codemod-remove-ember-css-modules/src/utils/steps/update-templates/update-template.ts
@@ -6,15 +6,21 @@ import { createFiles } from '@codemod-utils/files';
 
 import type { OptionsForUpdateTemplates } from '../../../types/index.js';
 
+type AttrNode = ReturnType<typeof AST.builders.attr>;
+type ConcatStatement = ReturnType<typeof AST.builders.concat>;
+type Expression = MustacheStatement['path'];
+type MustacheStatement = ReturnType<typeof AST.builders.mustache>;
+type SubExpression = ReturnType<typeof AST.builders.sexpr>;
+type TextNode = ReturnType<typeof AST.builders.text>;
+
 function sanitizeClassAndLocalClassAttributes(file: string): string {
   function removeAttributeWithoutValue(
     attributeName: string,
-    attributes: unknown[],
+    attributes: AttrNode[],
   ): void {
-    const attributeIndex = attributes.findIndex(
-      // @ts-expect-error: Incorrect type
-      (attribute) => attribute.name === attributeName,
-    );
+    const attributeIndex = attributes.findIndex((attribute) => {
+      return attribute.name === attributeName;
+    });
 
     if (attributeIndex === -1) {
       return;
@@ -22,20 +28,15 @@ function sanitizeClassAndLocalClassAttributes(file: string): string {
 
     const attribute = attributes[attributeIndex]!;
 
-    // @ts-expect-error: Incorrect type
     if (attribute.isValueless) {
       attributes.splice(attributeIndex, 1);
       return;
     }
 
-    // @ts-expect-error: Incorrect type
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (attribute.value.type !== 'TextNode') {
       return;
     }
 
-    // @ts-expect-error: Incorrect type
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const attributeValue = attribute.value.chars.trim();
 
     if (attributeValue === '') {
@@ -66,12 +67,13 @@ function mergeClassAndLocalClassAttributes(file: string): string {
       // Check that both class and local-class attributes exist
       const { attributes } = node;
 
-      const localClassAttributeIndex = attributes.findIndex(
-        (attribute) => attribute.name === 'local-class',
-      );
-      const classAttributeIndex = attributes.findIndex(
-        (attribute) => attribute.name === 'class',
-      );
+      const localClassAttributeIndex = attributes.findIndex((attribute) => {
+        return attribute.name === 'local-class';
+      });
+
+      const classAttributeIndex = attributes.findIndex((attribute) => {
+        return attribute.name === 'class';
+      });
 
       if (localClassAttributeIndex === -1 || classAttributeIndex === -1) {
         return;
@@ -129,16 +131,15 @@ function removeLocalClassHelpers(file: string): string {
     1 positional argument. The argument's value is presumed
     to be a concatenated string or `undefined`.
   */
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  function canRemoveLocalClassHelper(path: unknown) {
+  function canRemoveLocalClassHelper(
+    path: ConcatStatement | MustacheStatement | SubExpression | TextNode,
+  ): boolean {
     // @ts-expect-error: Incorrect type
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const hasFromArgument = path.hash.pairs.some((pair) => pair.key === 'from');
 
     if (hasFromArgument) {
       throw new RangeError(
-        // @ts-expect-error: Incorrect type
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         `Unable to handle the {{local-class}} helper's \`from\` key. See lines ${path.loc.start.line}-${path.loc.end.line}.`,
       );
     }
@@ -165,7 +166,6 @@ function removeLocalClassHelpers(file: string): string {
   const traverse = AST.traverse();
 
   const ast = traverse(file, {
-    // @ts-expect-error: Incorrect type
     AttrNode(node) {
       if (node.name !== 'class') {
         return;
@@ -173,7 +173,7 @@ function removeLocalClassHelpers(file: string): string {
 
       const hasLocalClassHelper =
         node.value.type === 'MustacheStatement' &&
-        // @ts-expect-error: Incorrect type
+        node.value.path.type === 'PathExpression' &&
         node.value.path.original === 'local-class';
 
       if (!hasLocalClassHelper) {
@@ -211,13 +211,16 @@ function removeLocalClassHelpers(file: string): string {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         ...localClassNames.map(AST.builders.string),
       ]);
+
+      return;
     },
 
     MustacheStatement(node) {
-      if (
-        node.path.type !== 'PathExpression' ||
-        node.path.original !== 'local-class'
-      ) {
+      const hasLocalClassHelper =
+        node.path.type === 'PathExpression' &&
+        node.path.original === 'local-class';
+
+      if (!hasLocalClassHelper) {
         return;
       }
 
@@ -242,8 +245,9 @@ function removeLocalClassHelpers(file: string): string {
     },
 
     SubExpression(node) {
-      // @ts-expect-error: Incorrect type
-      const hasLocalClassHelper = node.path.original === 'local-class';
+      const hasLocalClassHelper =
+        node.path.type === 'PathExpression' &&
+        node.path.original === 'local-class';
 
       if (!hasLocalClassHelper) {
         return;
@@ -276,24 +280,16 @@ function removeLocalClassHelpers(file: string): string {
 }
 
 function removeLocalClassAttributes(file: string): string {
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  function transformParam(param: unknown) {
-    // @ts-expect-error: Incorrect type
-    switch (param.type) {
+  function transformExpression(expression: Expression): Expression {
+    switch (expression.type) {
       case 'StringLiteral': {
-        // @ts-expect-error: Incorrect type
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        const localClassNames = param.value.trim().split(/\s+/);
+        const localClassNames = expression.value.trim().split(/\s+/);
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (localClassNames.length === 1) {
-          // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-          param.value = localClassNames[0]!;
+          expression.value = localClassNames[0]!;
         } else {
-          param = AST.builders.sexpr(
+          expression = AST.builders.sexpr(
             'array',
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             localClassNames.map(AST.builders.string),
           );
         }
@@ -302,18 +298,19 @@ function removeLocalClassAttributes(file: string): string {
       }
 
       case 'SubExpression': {
-        // @ts-expect-error: Incorrect type
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        switch (param.path.original) {
+        if (expression.path.type !== 'PathExpression') {
+          break;
+        }
+
+        switch (expression.path.original) {
           case 'if':
           case 'unless': {
-            // @ts-expect-error: Incorrect type
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            const subparams = param.params.map(transformParam);
+            const subparams = expression.params.map(transformExpression);
 
-            // @ts-expect-error: Incorrect type
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-            param = AST.builders.sexpr(param.path.original, subparams);
+            expression = AST.builders.sexpr(
+              expression.path.original,
+              subparams,
+            );
 
             break;
           }
@@ -323,57 +320,48 @@ function removeLocalClassAttributes(file: string): string {
       }
     }
 
-    return param;
+    return expression;
   }
 
-  // @ts-expect-error: Incorrect type
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  function transformPart(part: unknown) {
-    // @ts-expect-error: Incorrect type
+  function transformPart(
+    part: MustacheStatement | TextNode,
+  ): MustacheStatement | TextNode {
     switch (part.type) {
       case 'MustacheStatement': {
-        // @ts-expect-error: Incorrect type
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (part.path.type === 'SubExpression') {
+          return AST.builders.mustache(AST.builders.path('get'), [
+            AST.builders.path('this.styles'),
+            part.path,
+          ]);
+        }
+
         switch (part.path.original) {
           case 'concat': {
-            // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-            function hasPathExpression(params: unknown[]) {
-              // @ts-expect-error: Incorrect type
+            function hasPathExpression(params: Expression[]): boolean {
               return params.some((param) => param.type === 'PathExpression');
             }
 
-            // @ts-expect-error: Incorrect type
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             if (hasPathExpression(part.params)) {
               return AST.builders.mustache(AST.builders.path('get'), [
                 AST.builders.path('this.styles'),
-                // @ts-expect-error: Incorrect type
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
                 AST.builders.sexpr(part.path.original, part.params),
               ]);
             }
 
-            // @ts-expect-error: Incorrect type
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            const params = part.params.map(transformParam);
+            const params = part.params.map(transformExpression);
 
             return AST.builders.mustache('local', [
               AST.builders.path('this.styles'),
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               ...params,
             ]);
           }
 
           case 'if':
           case 'unless': {
-            // @ts-expect-error: Incorrect type
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            const params = part.params.map(transformParam);
+            const params = part.params.map(transformExpression);
 
             return AST.builders.mustache('local', [
               AST.builders.path('this.styles'),
-              // @ts-expect-error: Incorrect type
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
               AST.builders.sexpr(part.path.original, params),
             ]);
           }
@@ -381,7 +369,6 @@ function removeLocalClassAttributes(file: string): string {
           default: {
             return AST.builders.mustache(AST.builders.path('get'), [
               AST.builders.path('this.styles'),
-              // @ts-expect-error: Incorrect type
               part.path,
             ]);
           }
@@ -389,51 +376,45 @@ function removeLocalClassAttributes(file: string): string {
       }
 
       case 'TextNode': {
-        // @ts-expect-error: Incorrect type
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         const value = part.chars.trim();
 
         if (value === '') {
           return part;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         const localClassNames = value.split(/\s+/);
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (localClassNames.length === 1) {
           return AST.builders.mustache(
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             AST.builders.path(`this.styles.${localClassNames[0]!}`),
           );
         }
 
         return AST.builders.mustache(AST.builders.path('local'), [
           AST.builders.path('this.styles'),
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           ...localClassNames.map(AST.builders.string),
         ]);
       }
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  function transformParts(parts: unknown[]) {
+  function transformParts(
+    parts: (MustacheStatement | TextNode)[],
+  ): (MustacheStatement | TextNode)[] {
     const numParts = parts.length;
 
-    return parts.reduce((accumulator, part, index) => {
-      // @ts-expect-error: Incorrect type
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      accumulator.push(transformPart(part));
+    return parts.reduce(
+      (accumulator, part, index) => {
+        accumulator.push(transformPart(part));
 
-      if (index < numParts - 1) {
-        // @ts-expect-error: Incorrect type
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        accumulator.push(AST.builders.text(' '));
-      }
+        if (index < numParts - 1) {
+          accumulator.push(AST.builders.text(' '));
+        }
 
-      return accumulator;
-    }, [] as unknown[]);
+        return accumulator;
+      },
+      [] as (MustacheStatement | TextNode)[],
+    );
   }
 
   const traverse = AST.traverse();
@@ -467,7 +448,6 @@ function removeLocalClassAttributes(file: string): string {
 
         case 'MustacheStatement': {
           localClassAttribute.name = 'class';
-          // @ts-expect-error: Incorrect type
           localClassAttribute.value = transformPart(localClassAttribute.value);
 
           break;
@@ -475,7 +455,6 @@ function removeLocalClassAttributes(file: string): string {
 
         case 'TextNode': {
           localClassAttribute.name = 'class';
-          // @ts-expect-error: Incorrect type
           localClassAttribute.value = transformPart(localClassAttribute.value);
 
           break;
@@ -490,21 +469,16 @@ function removeLocalClassAttributes(file: string): string {
 
       node.key = 'class';
 
-      const newValue = transformParam(node.value);
+      const newValue = transformExpression(node.value);
 
-      // @ts-expect-error: Incorrect type
       if (newValue.type === 'StringLiteral') {
-        node.value = AST.builders.path(
-          // @ts-expect-error: Incorrect type
-          `this.styles.${newValue.value}`,
-        );
+        node.value = AST.builders.path(`this.styles.${newValue.value}`);
 
         return;
       }
 
       node.value = AST.builders.sexpr('local', [
         AST.builders.path('this.styles'),
-        // @ts-expect-error: Incorrect type
         newValue,
       ]);
     },


### PR DESCRIPTION
## Why?

Incorrect use of `recast` had led to unnecessary type errors. In general, `node.value` should have read `path.node` instead.
