### PR TITLE
Began testing ember-lts-6.12, ember-beta, and ember-canary scenarios

### DIFF
--- a/.changeset/lucky-melons-sip.md
+++ b/.changeset/lucky-melons-sip.md
@@ -1,0 +1,6 @@
+---
+"embroider-css-modules": patch
+"test-app-for-embroider-css-modules": patch
+---
+
+Began testing ember-lts-6.12, ember-beta, and ember-canary scenarios

--- a/docs/my-v2-app/package.json
+++ b/docs/my-v2-app/package.json
@@ -36,7 +36,7 @@
     "prelint:types": "type-css-modules --src app",
     "lint:types": "ember-tsc --noEmit",
     "start": "vite",
-    "test": "vite build --mode test && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
+    "test": "NODE_ENV=development vite build --mode development && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/tests/embroider-css-modules/.try.mjs
+++ b/tests/embroider-css-modules/.try.mjs
@@ -18,10 +18,10 @@ export default {
       },
     },
     {
-      name: 'ember-lts-6.8',
+      name: 'ember-lts-6.12',
       npm: {
         devDependencies: {
-          'ember-source': '~6.8.0',
+          'ember-source': '~6.12.0',
         },
       },
     },

--- a/tests/embroider-css-modules/.try.mjs
+++ b/tests/embroider-css-modules/.try.mjs
@@ -33,21 +33,21 @@ export default {
         },
       },
     },
-    // {
-    //   name: 'ember-beta',
-    //   npm: {
-    //     devDependencies: {
-    //       'ember-source': 'npm:ember-source@beta',
-    //     },
-    //   },
-    // },
-    // {
-    //   name: 'ember-canary',
-    //   npm: {
-    //     devDependencies: {
-    //       'ember-source': 'npm:ember-source@alpha',
-    //     },
-    //   },
-    // },
+    {
+      name: 'ember-beta',
+      npm: {
+        devDependencies: {
+          'ember-source': 'npm:ember-source@beta',
+        },
+      },
+    },
+    {
+      name: 'ember-canary',
+      npm: {
+        devDependencies: {
+          'ember-source': 'npm:ember-source@alpha',
+        },
+      },
+    },
   ],
 };

--- a/tests/embroider-css-modules/package.json
+++ b/tests/embroider-css-modules/package.json
@@ -35,7 +35,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "ember-tsc --noEmit",
     "start": "vite",
-    "test": "vite build --mode test && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
+    "test": "NODE_ENV=development vite build --mode development && ember test --config-file \"./testem.cjs\" --path dist --test-port 0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",


### PR DESCRIPTION
## Why?

Follows up on https://github.com/ijlee2/embroider-css-modules/pull/216 and https://github.com/ijlee2/embroider-css-modules/pull/238.


## What changed?

- Replaced `ember-lts-6.8` with `ember-lts-6.12`.
- Enabled `ember-beta` and `ember-canary` to show compatibility with `ember-source@7.0.0`.
